### PR TITLE
Fix goconst issues

### DIFF
--- a/account/request.go
+++ b/account/request.go
@@ -1,6 +1,10 @@
 package account
 
-import "github.com/opsgenie/opsgenie-go-sdk-v2/client"
+import (
+	"net/http"
+
+	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
+)
 
 type GetRequest struct {
 	client.BaseRequest
@@ -15,5 +19,5 @@ func (r *GetRequest) ResourcePath() string {
 }
 
 func (r *GetRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }

--- a/alert/acknowledge_request.go
+++ b/alert/acknowledge_request.go
@@ -1,6 +1,8 @@
 package alert
 
 import (
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/pkg/errors"
 )
@@ -28,7 +30,7 @@ func (r *AcknowledgeAlertRequest) ResourcePath() string {
 }
 
 func (r *AcknowledgeAlertRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 func (r *AcknowledgeAlertRequest) RequestParams() map[string]string {

--- a/alert/add_details_request.go
+++ b/alert/add_details_request.go
@@ -1,6 +1,8 @@
 package alert
 
 import (
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/pkg/errors"
 )
@@ -33,7 +35,7 @@ func (r *AddDetailsRequest) ResourcePath() string {
 }
 
 func (r *AddDetailsRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 func (r *AddDetailsRequest) RequestParams() map[string]string {

--- a/alert/add_note_request.go
+++ b/alert/add_note_request.go
@@ -1,6 +1,8 @@
 package alert
 
 import (
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/pkg/errors"
 )
@@ -31,7 +33,7 @@ func (r *AddNoteRequest) ResourcePath() string {
 }
 
 func (r *AddNoteRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 func (r *AddNoteRequest) RequestParams() map[string]string {

--- a/alert/add_responder.go
+++ b/alert/add_responder.go
@@ -1,6 +1,8 @@
 package alert
 
 import (
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/pkg/errors"
 )
@@ -40,7 +42,7 @@ func (r *AddResponderRequest) ResourcePath() string {
 }
 
 func (r *AddResponderRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 func (r *AddResponderRequest) RequestParams() map[string]string {

--- a/alert/add_tags_request.go
+++ b/alert/add_tags_request.go
@@ -1,6 +1,8 @@
 package alert
 
 import (
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/pkg/errors"
 )
@@ -33,7 +35,7 @@ func (r *AddTagsRequest) ResourcePath() string {
 }
 
 func (r *AddTagsRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 func (r *AddTagsRequest) RequestParams() map[string]string {

--- a/alert/add_team_request.go
+++ b/alert/add_team_request.go
@@ -1,6 +1,8 @@
 package alert
 
 import (
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/pkg/errors"
 )
@@ -33,7 +35,7 @@ func (r *AddTeamRequest) ResourcePath() string {
 }
 
 func (r *AddTeamRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 func (r *AddTeamRequest) RequestParams() map[string]string {

--- a/alert/assign_request.go
+++ b/alert/assign_request.go
@@ -1,6 +1,8 @@
 package alert
 
 import (
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/pkg/errors"
 )
@@ -33,7 +35,7 @@ func (r *AssignRequest) ResourcePath() string {
 }
 
 func (r *AssignRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 func (r *AssignRequest) RequestParams() map[string]string {

--- a/alert/close_alert_request.go
+++ b/alert/close_alert_request.go
@@ -1,6 +1,8 @@
 package alert
 
 import (
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/pkg/errors"
 )
@@ -28,7 +30,7 @@ func (r *CloseAlertRequest) ResourcePath() string {
 }
 
 func (r *CloseAlertRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 func (r *CloseAlertRequest) RequestParams() map[string]string {

--- a/alert/count_alerts_request.go
+++ b/alert/count_alerts_request.go
@@ -1,6 +1,8 @@
 package alert
 
 import (
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 )
 
@@ -20,7 +22,7 @@ func (r *CountAlertsRequest) ResourcePath() string {
 }
 
 func (r *CountAlertsRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *CountAlertsRequest) RequestParams() map[string]string {

--- a/alert/create_alert_attachment_request.go
+++ b/alert/create_alert_attachment_request.go
@@ -2,11 +2,13 @@ package alert
 
 import (
 	"errors"
-	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"io"
+	"net/http"
 	"os"
 	"path"
 	"strings"
+
+	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 )
 
 type CreateAlertAttachmentRequest struct {
@@ -53,7 +55,7 @@ func (r *CreateAlertAttachmentRequest) ResourcePath() string {
 }
 
 func (r *CreateAlertAttachmentRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 func (r *CreateAlertAttachmentRequest) RequestParams() map[string]string {

--- a/alert/create_alert_request.go
+++ b/alert/create_alert_request.go
@@ -2,6 +2,8 @@ package alert
 
 import (
 	"errors"
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 )
 
@@ -35,5 +37,5 @@ func (r *CreateAlertRequest) ResourcePath() string {
 }
 
 func (r *CreateAlertRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }

--- a/alert/create_saved_search_request.go
+++ b/alert/create_saved_search_request.go
@@ -1,6 +1,8 @@
 package alert
 
 import (
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/pkg/errors"
 )
@@ -36,5 +38,5 @@ func (r *CreateSavedSearchRequest) ResourcePath() string {
 }
 
 func (r *CreateSavedSearchRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }

--- a/alert/delete_alert_request.go
+++ b/alert/delete_alert_request.go
@@ -1,6 +1,8 @@
 package alert
 
 import (
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 )
 
@@ -25,7 +27,7 @@ func (r *DeleteAlertRequest) ResourcePath() string {
 }
 
 func (r *DeleteAlertRequest) Method() string {
-	return "DELETE"
+	return http.MethodDelete
 }
 
 func (r *DeleteAlertRequest) RequestParams() map[string]string {

--- a/alert/delete_attachment_request.go
+++ b/alert/delete_attachment_request.go
@@ -1,6 +1,8 @@
 package alert
 
 import (
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/pkg/errors"
 )
@@ -30,7 +32,7 @@ func (r *DeleteAttachmentRequest) ResourcePath() string {
 }
 
 func (r *DeleteAttachmentRequest) Method() string {
-	return "DELETE"
+	return http.MethodDelete
 }
 
 func (r *DeleteAttachmentRequest) RequestParams() map[string]string {

--- a/alert/delete_saved_search_request.go
+++ b/alert/delete_saved_search_request.go
@@ -1,6 +1,8 @@
 package alert
 
 import (
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 )
 
@@ -24,7 +26,7 @@ func (r *DeleteSavedSearchRequest) ResourcePath() string {
 }
 
 func (r *DeleteSavedSearchRequest) Method() string {
-	return "DELETE"
+	return http.MethodDelete
 }
 
 func (r *DeleteSavedSearchRequest) RequestParams() map[string]string {

--- a/alert/escalate_to_next_request.go
+++ b/alert/escalate_to_next_request.go
@@ -1,6 +1,8 @@
 package alert
 
 import (
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/pkg/errors"
 )
@@ -33,7 +35,7 @@ func (r *EscalateToNextRequest) ResourcePath() string {
 }
 
 func (r *EscalateToNextRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 func (r *EscalateToNextRequest) RequestParams() map[string]string {

--- a/alert/execute_custom_action.go
+++ b/alert/execute_custom_action.go
@@ -1,6 +1,8 @@
 package alert
 
 import (
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/pkg/errors"
 )
@@ -32,7 +34,7 @@ func (r *ExecuteCustomActionAlertRequest) ResourcePath() string {
 }
 
 func (r *ExecuteCustomActionAlertRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 func (r *ExecuteCustomActionAlertRequest) RequestParams() map[string]string {

--- a/alert/get_alert_request.go
+++ b/alert/get_alert_request.go
@@ -1,6 +1,10 @@
 package alert
 
-import "github.com/opsgenie/opsgenie-go-sdk-v2/client"
+import (
+	"net/http"
+
+	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
+)
 
 type GetAlertRequest struct {
 	client.BaseRequest
@@ -21,7 +25,7 @@ func (r *GetAlertRequest) ResourcePath() string {
 }
 
 func (r *GetAlertRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *GetAlertRequest) RequestParams() map[string]string {

--- a/alert/get_attachment_request.go
+++ b/alert/get_attachment_request.go
@@ -1,6 +1,8 @@
 package alert
 
 import (
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/pkg/errors"
 )
@@ -29,7 +31,7 @@ func (r *GetAttachmentRequest) ResourcePath() string {
 }
 
 func (r *GetAttachmentRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *GetAttachmentRequest) RequestParams() map[string]string {

--- a/alert/get_request_status_request.go
+++ b/alert/get_request_status_request.go
@@ -1,6 +1,8 @@
 package alert
 
 import (
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/pkg/errors"
 )
@@ -23,5 +25,5 @@ func (r *GetRequestStatusRequest) ResourcePath() string {
 }
 
 func (r *GetRequestStatusRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }

--- a/alert/get_saved_search_request.go
+++ b/alert/get_saved_search_request.go
@@ -1,6 +1,10 @@
 package alert
 
-import "github.com/opsgenie/opsgenie-go-sdk-v2/client"
+import (
+	"net/http"
+
+	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
+)
 
 type GetSavedSearchRequest struct {
 	client.BaseRequest
@@ -22,7 +26,7 @@ func (r *GetSavedSearchRequest) ResourcePath() string {
 }
 
 func (r *GetSavedSearchRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *GetSavedSearchRequest) RequestParams() map[string]string {

--- a/alert/list_alert_logs_request.go
+++ b/alert/list_alert_logs_request.go
@@ -1,8 +1,10 @@
 package alert
 
 import (
-	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
+	"net/http"
 	"strconv"
+
+	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 )
 
 type ListAlertLogsRequest struct {
@@ -28,7 +30,7 @@ func (r *ListAlertLogsRequest) ResourcePath() string {
 }
 
 func (r *ListAlertLogsRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *ListAlertLogsRequest) RequestParams() map[string]string {

--- a/alert/list_alert_notes_request.go
+++ b/alert/list_alert_notes_request.go
@@ -1,8 +1,10 @@
 package alert
 
 import (
-	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
+	"net/http"
 	"strconv"
+
+	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 )
 
 type ListAlertNotesRequest struct {
@@ -28,7 +30,7 @@ func (r *ListAlertNotesRequest) ResourcePath() string {
 }
 
 func (r *ListAlertNotesRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *ListAlertNotesRequest) RequestParams() map[string]string {

--- a/alert/list_alert_recipient_request.go
+++ b/alert/list_alert_recipient_request.go
@@ -1,6 +1,10 @@
 package alert
 
-import "github.com/opsgenie/opsgenie-go-sdk-v2/client"
+import (
+	"net/http"
+
+	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
+)
 
 type ListAlertRecipientRequest struct {
 	client.BaseRequest
@@ -22,7 +26,7 @@ func (r *ListAlertRecipientRequest) ResourcePath() string {
 }
 
 func (r *ListAlertRecipientRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *ListAlertRecipientRequest) RequestParams() map[string]string {

--- a/alert/list_alert_request.go
+++ b/alert/list_alert_request.go
@@ -1,8 +1,10 @@
 package alert
 
 import (
-	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
+	"net/http"
 	"strconv"
+
+	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 )
 
 type ListAlertRequest struct {
@@ -27,7 +29,7 @@ func (r *ListAlertRequest) ResourcePath() string {
 }
 
 func (r *ListAlertRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *ListAlertRequest) RequestParams() map[string]string {

--- a/alert/list_attachments_request.go
+++ b/alert/list_attachments_request.go
@@ -1,6 +1,8 @@
 package alert
 
 import (
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/pkg/errors"
 )
@@ -24,7 +26,7 @@ func (r *ListAttachmentsRequest) ResourcePath() string {
 }
 
 func (r *ListAttachmentsRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *ListAttachmentsRequest) RequestParams() map[string]string {

--- a/alert/list_saved_search_request.go
+++ b/alert/list_saved_search_request.go
@@ -1,6 +1,10 @@
 package alert
 
-import "github.com/opsgenie/opsgenie-go-sdk-v2/client"
+import (
+	"net/http"
+
+	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
+)
 
 type ListSavedSearchRequest struct {
 	client.BaseRequest
@@ -17,5 +21,5 @@ func (r *ListSavedSearchRequest) ResourcePath() string {
 }
 
 func (r *ListSavedSearchRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }

--- a/alert/remove_details_request.go
+++ b/alert/remove_details_request.go
@@ -1,6 +1,8 @@
 package alert
 
 import (
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/pkg/errors"
 )
@@ -32,7 +34,7 @@ func (r *RemoveDetailsRequest) ResourcePath() string {
 }
 
 func (r *RemoveDetailsRequest) Method() string {
-	return "DELETE"
+	return http.MethodDelete
 }
 
 func (r *RemoveDetailsRequest) RequestParams() map[string]string {

--- a/alert/remove_tags_request.go
+++ b/alert/remove_tags_request.go
@@ -1,6 +1,8 @@
 package alert
 
 import (
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/pkg/errors"
 )
@@ -32,7 +34,7 @@ func (r *RemoveTagsRequest) ResourcePath() string {
 }
 
 func (r *RemoveTagsRequest) Method() string {
-	return "DELETE"
+	return http.MethodDelete
 }
 
 func (r *RemoveTagsRequest) RequestParams() map[string]string {

--- a/alert/snooze_request.go
+++ b/alert/snooze_request.go
@@ -1,9 +1,11 @@
 package alert
 
 import (
+	"net/http"
+	"time"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/pkg/errors"
-	"time"
 )
 
 type SnoozeAlertRequest struct {
@@ -34,7 +36,7 @@ func (r *SnoozeAlertRequest) ResourcePath() string {
 }
 
 func (r *SnoozeAlertRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 func (r *SnoozeAlertRequest) RequestParams() map[string]string {

--- a/alert/unacknowledge_request.go
+++ b/alert/unacknowledge_request.go
@@ -1,6 +1,8 @@
 package alert
 
 import (
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/pkg/errors"
 )
@@ -28,7 +30,7 @@ func (r *UnacknowledgeAlertRequest) ResourcePath() string {
 }
 
 func (r *UnacknowledgeAlertRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 func (r *UnacknowledgeAlertRequest) RequestParams() map[string]string {

--- a/alert/update_description_request.go
+++ b/alert/update_description_request.go
@@ -1,6 +1,8 @@
 package alert
 
 import (
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/pkg/errors"
 )
@@ -28,7 +30,7 @@ func (r *UpdateDescriptionRequest) ResourcePath() string {
 }
 
 func (r *UpdateDescriptionRequest) Method() string {
-	return "PUT"
+	return http.MethodPut
 }
 
 func (r *UpdateDescriptionRequest) RequestParams() map[string]string {

--- a/alert/update_message_request.go
+++ b/alert/update_message_request.go
@@ -1,6 +1,8 @@
 package alert
 
 import (
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/pkg/errors"
 )
@@ -28,7 +30,7 @@ func (r *UpdateMessageRequest) ResourcePath() string {
 }
 
 func (r *UpdateMessageRequest) Method() string {
-	return "PUT"
+	return http.MethodPut
 }
 
 func (r *UpdateMessageRequest) RequestParams() map[string]string {

--- a/alert/update_priority_request.go
+++ b/alert/update_priority_request.go
@@ -1,6 +1,8 @@
 package alert
 
 import (
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/pkg/errors"
 )
@@ -33,7 +35,7 @@ func (r *UpdatePriorityRequest) ResourcePath() string {
 }
 
 func (r *UpdatePriorityRequest) Method() string {
-	return "PUT"
+	return http.MethodPut
 }
 
 func (r *UpdatePriorityRequest) RequestParams() map[string]string {

--- a/alert/update_saved_search_request.go
+++ b/alert/update_saved_search_request.go
@@ -1,6 +1,8 @@
 package alert
 
 import (
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/pkg/errors"
 )
@@ -43,7 +45,7 @@ func (r *UpdateSavedSearchRequest) ResourcePath() string {
 }
 
 func (r *UpdateSavedSearchRequest) Method() string {
-	return "PATCH"
+	return http.MethodPatch
 }
 
 func (r *UpdateSavedSearchRequest) RequestParams() map[string]string {

--- a/client/client.go
+++ b/client/client.go
@@ -45,7 +45,7 @@ type BaseRequest struct {
 
 func (r *BaseRequest) Metadata(apiRequest ApiRequest) map[string]interface{} {
 	headers := make(map[string]interface{})
-	if apiRequest.Method() != http.MethodGet && apiRequest.Method() != "DELETE" {
+	if apiRequest.Method() != http.MethodGet && apiRequest.Method() != http.MethodDelete {
 		headers["Content-Type"] = "application/json; charset=utf-8"
 	} else if apiRequest.Method() == http.MethodGet {
 		headers["Content-Type"] = "application/x-www-form-urlencoded; charset=UTF-8"
@@ -332,7 +332,7 @@ func (cli *OpsGenieClient) buildHttpRequest(apiRequest ApiRequest) (*request, er
 	details := apiRequest.Metadata(apiRequest)
 	if values, ok := details["form-data-values"].(map[string]io.Reader); ok {
 		setBodyAsFormData(&buf, values, contentType)
-	} else if apiRequest.Method() != http.MethodGet && apiRequest.Method() != "DELETE" {
+	} else if apiRequest.Method() != http.MethodGet && apiRequest.Method() != http.MethodDelete {
 		err = setBodyAsJson(&buf, apiRequest, contentType, details)
 	}
 	if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -5,9 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/go-retryablehttp"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"io"
 	"io/ioutil"
 	"mime/multipart"
@@ -19,6 +16,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 type OpsGenieClient struct {
@@ -45,9 +45,9 @@ type BaseRequest struct {
 
 func (r *BaseRequest) Metadata(apiRequest ApiRequest) map[string]interface{} {
 	headers := make(map[string]interface{})
-	if apiRequest.Method() != "GET" && apiRequest.Method() != "DELETE" {
+	if apiRequest.Method() != http.MethodGet && apiRequest.Method() != "DELETE" {
 		headers["Content-Type"] = "application/json; charset=utf-8"
-	} else if apiRequest.Method() == "GET" {
+	} else if apiRequest.Method() == http.MethodGet {
 		headers["Content-Type"] = "application/x-www-form-urlencoded; charset=UTF-8"
 	}
 	return headers
@@ -332,7 +332,7 @@ func (cli *OpsGenieClient) buildHttpRequest(apiRequest ApiRequest) (*request, er
 	details := apiRequest.Metadata(apiRequest)
 	if values, ok := details["form-data-values"].(map[string]io.Reader); ok {
 		setBodyAsFormData(&buf, values, contentType)
-	} else if apiRequest.Method() != "GET" && apiRequest.Method() != "DELETE" {
+	} else if apiRequest.Method() != http.MethodGet && apiRequest.Method() != "DELETE" {
 		err = setBodyAsJson(&buf, apiRequest, contentType, details)
 	}
 	if err != nil {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -3,14 +3,15 @@ package client
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -66,7 +67,7 @@ func (tr testRequest) ResourcePath() string {
 }
 
 func (tr testRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 type testResult struct {

--- a/contact/contact_test.go
+++ b/contact/contact_test.go
@@ -1,9 +1,11 @@
 package contact
 
 import (
+	"net/http"
+	"testing"
+
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestCreateRequest_Validate(t *testing.T) {
@@ -44,7 +46,7 @@ func TestGetRequest_Validate(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, getRequest.ResourcePath(), "/v2/users/123/contacts/1234")
-	assert.Equal(t, getRequest.Method(), "GET")
+	assert.Equal(t, getRequest.Method(), http.MethodGet)
 
 }
 
@@ -100,7 +102,7 @@ func TestListRequest_Validate(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, listRequest.ResourcePath(), "/v2/users/123/contacts")
-	assert.Equal(t, listRequest.Method(), "GET")
+	assert.Equal(t, listRequest.Method(), http.MethodGet)
 
 }
 

--- a/contact/contact_test.go
+++ b/contact/contact_test.go
@@ -27,7 +27,7 @@ func TestCreateRequest_Validate(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, createRequest.ResourcePath(), "/v2/users/123/contacts")
-	assert.Equal(t, createRequest.Method(), "POST")
+	assert.Equal(t, createRequest.Method(), http.MethodPost)
 
 }
 
@@ -121,7 +121,7 @@ func TestEnableRequest_Validate(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, enableRequest.ResourcePath(), "/v2/users/123/contacts/1234/enable")
-	assert.Equal(t, enableRequest.Method(), "POST")
+	assert.Equal(t, enableRequest.Method(), http.MethodPost)
 
 }
 
@@ -140,6 +140,6 @@ func TestDisableRequest_Validate(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, disableRequest.ResourcePath(), "/v2/users/123/contacts/1234/disable")
-	assert.Equal(t, disableRequest.Method(), "POST")
+	assert.Equal(t, disableRequest.Method(), http.MethodPost)
 
 }

--- a/contact/contact_test.go
+++ b/contact/contact_test.go
@@ -69,7 +69,7 @@ func TestUpdateRequest_Validate(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, updateRequest.ResourcePath(), "/v2/users/123/contacts/1234")
-	assert.Equal(t, updateRequest.Method(), "PATCH")
+	assert.Equal(t, updateRequest.Method(), http.MethodPatch)
 
 }
 func TestDeleteRequest_Validate(t *testing.T) {

--- a/contact/contact_test.go
+++ b/contact/contact_test.go
@@ -87,7 +87,7 @@ func TestDeleteRequest_Validate(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, deleteRequest.ResourcePath(), "/v2/users/123/contacts/1234")
-	assert.Equal(t, deleteRequest.Method(), "DELETE")
+	assert.Equal(t, deleteRequest.Method(), http.MethodDelete)
 
 }
 

--- a/contact/request.go
+++ b/contact/request.go
@@ -105,7 +105,7 @@ func (r *DeleteRequest) ResourcePath() string {
 }
 
 func (r *DeleteRequest) Method() string {
-	return "DELETE"
+	return http.MethodDelete
 }
 
 type ListRequest struct {

--- a/contact/request.go
+++ b/contact/request.go
@@ -1,6 +1,8 @@
 package contact
 
 import (
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/pkg/errors"
 )
@@ -53,7 +55,7 @@ func (r *GetRequest) ResourcePath() string {
 }
 
 func (r *GetRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 type UpdateRequest struct {
@@ -122,7 +124,7 @@ func (r *ListRequest) ResourcePath() string {
 }
 
 func (r *ListRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 type EnableRequest struct {

--- a/contact/request.go
+++ b/contact/request.go
@@ -33,7 +33,7 @@ func (r *CreateRequest) ResourcePath() string {
 }
 
 func (r *CreateRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 type GetRequest struct {
@@ -145,7 +145,7 @@ func (r *EnableRequest) ResourcePath() string {
 }
 
 func (r *EnableRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 type DisableRequest struct {
@@ -166,7 +166,7 @@ func (r *DisableRequest) ResourcePath() string {
 }
 
 func (r *DisableRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 func validateIdentifier(userIdentifier string, contactIdentifier string) error {

--- a/contact/request.go
+++ b/contact/request.go
@@ -84,7 +84,7 @@ func (r *UpdateRequest) ResourcePath() string {
 }
 
 func (r *UpdateRequest) Method() string {
-	return "PATCH"
+	return http.MethodPatch
 }
 
 type DeleteRequest struct {

--- a/custom_user_role/request.go
+++ b/custom_user_role/request.go
@@ -47,7 +47,7 @@ func (r *CreateRequest) ResourcePath() string {
 }
 
 func (r *CreateRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 type GetRequest struct {

--- a/custom_user_role/request.go
+++ b/custom_user_role/request.go
@@ -148,7 +148,7 @@ func (r *DeleteRequest) ResourcePath() string {
 }
 
 func (r *DeleteRequest) Method() string {
-	return "DELETE"
+	return http.MethodDelete
 }
 
 func (r *DeleteRequest) RequestParams() map[string]string {

--- a/custom_user_role/request.go
+++ b/custom_user_role/request.go
@@ -1,6 +1,8 @@
 package custom_user_role
 
 import (
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/pkg/errors"
 )
@@ -67,7 +69,7 @@ func (r *GetRequest) ResourcePath() string {
 }
 
 func (r *GetRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *GetRequest) RequestParams() map[string]string {
@@ -175,5 +177,5 @@ func (r *ListRequest) ResourcePath() string {
 }
 
 func (r *ListRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }

--- a/custom_user_role/request.go
+++ b/custom_user_role/request.go
@@ -114,7 +114,7 @@ func (r *UpdateRequest) ResourcePath() string {
 }
 
 func (r *UpdateRequest) Method() string {
-	return "PUT"
+	return http.MethodPut
 }
 
 func (r *UpdateRequest) RequestParams() map[string]string {

--- a/escalation/request.go
+++ b/escalation/request.go
@@ -61,7 +61,7 @@ func (r *CreateRequest) ResourcePath() string {
 }
 
 func (r *CreateRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 type GetRequest struct {

--- a/escalation/request.go
+++ b/escalation/request.go
@@ -158,7 +158,7 @@ func (r *DeleteRequest) Validate() error {
 }
 
 func (r *DeleteRequest) Method() string {
-	return "DELETE"
+	return http.MethodDelete
 }
 
 func (r *DeleteRequest) ResourcePath() string {

--- a/escalation/request.go
+++ b/escalation/request.go
@@ -1,6 +1,8 @@
 package escalation
 
 import (
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/og"
 	"github.com/pkg/errors"
@@ -77,7 +79,7 @@ func (r *GetRequest) Validate() error {
 }
 
 func (r *GetRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *GetRequest) ResourcePath() string {
@@ -185,7 +187,7 @@ func (r *listRequest) Validate() error {
 }
 
 func (r *listRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *listRequest) ResourcePath() string {

--- a/escalation/request.go
+++ b/escalation/request.go
@@ -140,7 +140,7 @@ func (r *UpdateRequest) RequestParams() map[string]string {
 }
 
 func (r *UpdateRequest) Method() string {
-	return "PATCH"
+	return http.MethodPatch
 }
 
 type DeleteRequest struct {

--- a/forwarding_rule/forwarding_rule_test.go
+++ b/forwarding_rule/forwarding_rule_test.go
@@ -110,7 +110,7 @@ func TestValidateDeleteRequest(t *testing.T) {
 
 	assert.Equal(t, deleteRequest.ResourcePath(), "/v2/forwarding-rules/123")
 	assert.Equal(t, deleteRequest.RequestParams(), map[string]string{"identifierType": "id"})
-	assert.Equal(t, deleteRequest.Method(), "DELETE")
+	assert.Equal(t, deleteRequest.Method(), http.MethodDelete)
 
 	deleteRequest.IdentifierType = Alias
 	deleteRequest.IdentifierValue = "abc"

--- a/forwarding_rule/forwarding_rule_test.go
+++ b/forwarding_rule/forwarding_rule_test.go
@@ -33,7 +33,7 @@ func TestValidateCreateRequest(t *testing.T) {
 
 	assert.Equal(t, createRequest.ResourcePath(), "/v2/forwarding-rules")
 	assert.Equal(t, createRequest.RequestParams(), make(map[string]string))
-	assert.Equal(t, createRequest.Method(), "POST")
+	assert.Equal(t, createRequest.Method(), http.MethodPost)
 }
 
 func TestValidateGetRequest(t *testing.T) {

--- a/forwarding_rule/forwarding_rule_test.go
+++ b/forwarding_rule/forwarding_rule_test.go
@@ -87,7 +87,7 @@ func TestValidateUpdateRequest(t *testing.T) {
 
 	assert.Equal(t, updateRequest.ResourcePath(), "/v2/forwarding-rules/123")
 	assert.Equal(t, updateRequest.RequestParams(), map[string]string{"identifierType": "id"})
-	assert.Equal(t, updateRequest.Method(), "PUT")
+	assert.Equal(t, updateRequest.Method(), http.MethodPut)
 
 	updateRequest.IdentifierType = Alias
 	updateRequest.IdentifierValue = "abc"

--- a/forwarding_rule/forwarding_rule_test.go
+++ b/forwarding_rule/forwarding_rule_test.go
@@ -1,10 +1,12 @@
 package forwarding_rule
 
 import (
-	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
+	"net/http"
 	"testing"
 	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestValidateCreateRequest(t *testing.T) {
@@ -46,7 +48,7 @@ func TestValidateGetRequest(t *testing.T) {
 
 	assert.Equal(t, getRequest.ResourcePath(), "/v2/forwarding-rules/123")
 	assert.Equal(t, getRequest.RequestParams(), map[string]string{"identifierType": "id"})
-	assert.Equal(t, getRequest.Method(), "GET")
+	assert.Equal(t, getRequest.Method(), http.MethodGet)
 
 	getRequest.IdentifierType = Alias
 	getRequest.IdentifierValue = "abc"
@@ -127,6 +129,6 @@ func TestValidateListRequest(t *testing.T) {
 
 	assert.Equal(t, listRequest.ResourcePath(), "/v2/forwarding-rules")
 	assert.Equal(t, listRequest.RequestParams(), make(map[string]string))
-	assert.Equal(t, listRequest.Method(), "GET")
+	assert.Equal(t, listRequest.Method(), http.MethodGet)
 
 }

--- a/forwarding_rule/request.go
+++ b/forwarding_rule/request.go
@@ -48,7 +48,7 @@ func (r *CreateRequest) ResourcePath() string {
 }
 
 func (r *CreateRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 func (r *CreateRequest) RequestParams() map[string]string {

--- a/forwarding_rule/request.go
+++ b/forwarding_rule/request.go
@@ -1,9 +1,11 @@
 package forwarding_rule
 
 import (
+	"net/http"
+	"time"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/pkg/errors"
-	"time"
 )
 
 type Identifier uint32
@@ -74,7 +76,7 @@ func (r *GetRequest) ResourcePath() string {
 }
 
 func (r *GetRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *GetRequest) RequestParams() map[string]string {
@@ -198,7 +200,7 @@ func (r *ListRequest) ResourcePath() string {
 }
 
 func (r *ListRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *ListRequest) RequestParams() map[string]string {

--- a/forwarding_rule/request.go
+++ b/forwarding_rule/request.go
@@ -134,7 +134,7 @@ func (r *UpdateRequest) ResourcePath() string {
 }
 
 func (r *UpdateRequest) Method() string {
-	return "PUT"
+	return http.MethodPut
 }
 
 func (r *UpdateRequest) RequestParams() map[string]string {

--- a/forwarding_rule/request.go
+++ b/forwarding_rule/request.go
@@ -170,7 +170,7 @@ func (r *DeleteRequest) ResourcePath() string {
 }
 
 func (r *DeleteRequest) Method() string {
-	return "DELETE"
+	return http.MethodDelete
 }
 
 func (r *DeleteRequest) RequestParams() map[string]string {

--- a/heartbeat/request.go
+++ b/heartbeat/request.go
@@ -99,7 +99,7 @@ func (r UpdateRequest) ResourcePath() string {
 }
 
 func (r UpdateRequest) Method() string {
-	return "PATCH"
+	return http.MethodPatch
 }
 
 type AddRequest struct {

--- a/heartbeat/request.go
+++ b/heartbeat/request.go
@@ -2,6 +2,8 @@ package heartbeat
 
 import (
 	"errors"
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/og"
 )
@@ -27,7 +29,7 @@ func (r pingRequest) ResourcePath() string {
 }
 
 func (r pingRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 type getRequest struct {
@@ -44,7 +46,7 @@ func (r getRequest) ResourcePath() string {
 }
 
 func (r getRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 type listRequest struct {
@@ -60,7 +62,7 @@ func (r listRequest) ResourcePath() string {
 }
 
 func (r listRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 type UpdateRequest struct {

--- a/heartbeat/request.go
+++ b/heartbeat/request.go
@@ -136,7 +136,7 @@ func (r AddRequest) ResourcePath() string {
 }
 
 func (r AddRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 type Unit string
@@ -164,7 +164,7 @@ func (r enableRequest) ResourcePath() string {
 }
 
 func (r enableRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 type disableRequest struct {
@@ -184,5 +184,5 @@ func (r disableRequest) ResourcePath() string {
 }
 
 func (r disableRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }

--- a/incident/request.go
+++ b/incident/request.go
@@ -73,7 +73,7 @@ func (r *CreateRequest) ResourcePath() string {
 }
 
 func (r *CreateRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 type DeleteRequest struct {
@@ -219,7 +219,7 @@ func (r *CloseRequest) ResourcePath() string {
 }
 
 func (r *CloseRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 func (r *CloseRequest) RequestParams() map[string]string {
@@ -258,7 +258,7 @@ func (r *AddNoteRequest) ResourcePath() string {
 }
 
 func (r *AddNoteRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 func (r *AddNoteRequest) RequestParams() map[string]string {
@@ -305,7 +305,7 @@ func (r *AddResponderRequest) ResourcePath() string {
 }
 
 func (r *AddResponderRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 func (r *AddResponderRequest) RequestParams() map[string]string {
@@ -347,7 +347,7 @@ func (r *AddTagsRequest) ResourcePath() string {
 }
 
 func (r *AddTagsRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 func (r *AddTagsRequest) RequestParams() map[string]string {
@@ -438,7 +438,7 @@ func (r *AddDetailsRequest) ResourcePath() string {
 }
 
 func (r *AddDetailsRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 func (r *AddDetailsRequest) RequestParams() map[string]string {
@@ -569,7 +569,7 @@ func (r *UpdateMessageRequest) ResourcePath() string {
 }
 
 func (r *UpdateMessageRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 func (r *UpdateMessageRequest) RequestParams() map[string]string {
@@ -607,7 +607,7 @@ func (r *UpdateDescriptionRequest) ResourcePath() string {
 }
 
 func (r *UpdateDescriptionRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 func (r *UpdateDescriptionRequest) RequestParams() map[string]string {

--- a/incident/request.go
+++ b/incident/request.go
@@ -1,10 +1,12 @@
 package incident
 
 import (
-	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
-	"github.com/pkg/errors"
+	"net/http"
 	"strconv"
 	"strings"
+
+	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
+	"github.com/pkg/errors"
 )
 
 type RequestStatusRequest struct {
@@ -24,7 +26,7 @@ func (r *RequestStatusRequest) ResourcePath() string {
 }
 
 func (r *RequestStatusRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 type CreateRequest struct {
@@ -132,7 +134,7 @@ func (r *GetRequest) ResourcePath() string {
 }
 
 func (r *GetRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *GetRequest) RequestParams() map[string]string {
@@ -168,7 +170,7 @@ func (r *ListRequest) ResourcePath() string {
 }
 
 func (r *ListRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *ListRequest) RequestParams() map[string]string {
@@ -646,7 +648,7 @@ func (r *ListLogsRequest) ResourcePath() string {
 }
 
 func (r *ListLogsRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *ListLogsRequest) RequestParams() map[string]string {
@@ -702,7 +704,7 @@ func (r *ListNotesRequest) ResourcePath() string {
 }
 
 func (r *ListNotesRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *ListNotesRequest) RequestParams() map[string]string {

--- a/incident/request.go
+++ b/incident/request.go
@@ -97,7 +97,7 @@ func (r *DeleteRequest) ResourcePath() string {
 }
 
 func (r *DeleteRequest) Method() string {
-	return "DELETE"
+	return http.MethodDelete
 }
 
 func (r *DeleteRequest) RequestParams() map[string]string {
@@ -389,7 +389,7 @@ func (r *RemoveTagsRequest) ResourcePath() string {
 }
 
 func (r *RemoveTagsRequest) Method() string {
-	return "DELETE"
+	return http.MethodDelete
 }
 
 func (r *RemoveTagsRequest) RequestParams() map[string]string {
@@ -480,7 +480,7 @@ func (r *RemoveDetailsRequest) ResourcePath() string {
 }
 
 func (r *RemoveDetailsRequest) Method() string {
-	return "DELETE"
+	return http.MethodDelete
 }
 
 func (r *RemoveDetailsRequest) RequestParams() map[string]string {

--- a/incident/request.go
+++ b/incident/request.go
@@ -530,7 +530,7 @@ func (r *UpdatePriorityRequest) ResourcePath() string {
 }
 
 func (r *UpdatePriorityRequest) Method() string {
-	return "PUT"
+	return http.MethodPut
 }
 
 func (r *UpdatePriorityRequest) RequestParams() map[string]string {

--- a/integration/request.go
+++ b/integration/request.go
@@ -143,7 +143,7 @@ func (r OtherFields) ResourcePath() string {
 }
 
 func (r OtherFields) Method() string {
-	return "PUT"
+	return http.MethodPut
 }
 
 func (r OtherFields) RequestParams() map[string]string {
@@ -370,7 +370,7 @@ func (r *UpdateAllIntegrationActionsRequest) ResourcePath() string {
 }
 
 func (r *UpdateAllIntegrationActionsRequest) Method() string {
-	return "PUT"
+	return http.MethodPut
 }
 
 func validateRecipients(recipients []Recipient) error {

--- a/integration/request.go
+++ b/integration/request.go
@@ -1,6 +1,8 @@
 package integration
 
 import (
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/og"
 	"github.com/pkg/errors"
@@ -23,7 +25,7 @@ func (r *GetRequest) ResourcePath() string {
 }
 
 func (r *GetRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 type listRequest struct {
@@ -39,7 +41,7 @@ func (r *listRequest) ResourcePath() string {
 }
 
 func (r *listRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 type APIBasedIntegrationRequest struct {
@@ -252,7 +254,7 @@ func (r *GetIntegrationActionsRequest) ResourcePath() string {
 }
 
 func (r *GetIntegrationActionsRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 type CreateIntegrationActionsRequest struct {

--- a/integration/request.go
+++ b/integration/request.go
@@ -174,7 +174,7 @@ func (r *DeleteIntegrationRequest) ResourcePath() string {
 }
 
 func (r *DeleteIntegrationRequest) Method() string {
-	return "DELETE"
+	return http.MethodDelete
 }
 
 type EnableIntegrationRequest struct {

--- a/integration/request.go
+++ b/integration/request.go
@@ -72,7 +72,7 @@ func (r *APIBasedIntegrationRequest) ResourcePath() string {
 }
 
 func (r *APIBasedIntegrationRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 type EmailBasedIntegrationRequest struct {
@@ -102,7 +102,7 @@ func (r *EmailBasedIntegrationRequest) ResourcePath() string {
 }
 
 func (r *EmailBasedIntegrationRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 type UpdateIntegrationRequest struct {
@@ -194,7 +194,7 @@ func (r *EnableIntegrationRequest) ResourcePath() string {
 }
 
 func (r *EnableIntegrationRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 type DisableIntegrationRequest struct {
@@ -214,7 +214,7 @@ func (r *DisableIntegrationRequest) ResourcePath() string {
 }
 
 func (r *DisableIntegrationRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 type AuthenticateIntegrationRequest struct {
@@ -234,7 +234,7 @@ func (r *AuthenticateIntegrationRequest) ResourcePath() string {
 }
 
 func (r *AuthenticateIntegrationRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 type GetIntegrationActionsRequest struct {
@@ -312,7 +312,7 @@ func (r *CreateIntegrationActionsRequest) ResourcePath() string {
 }
 
 func (r *CreateIntegrationActionsRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 type UpdateAllIntegrationActionsRequest struct {

--- a/logs/request.go
+++ b/logs/request.go
@@ -1,9 +1,11 @@
 package logs
 
 import (
+	"net/http"
+	"strconv"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/pkg/errors"
-	"strconv"
 )
 
 type ListLogFilesRequest struct {
@@ -25,7 +27,7 @@ func (r *ListLogFilesRequest) ResourcePath() string {
 }
 
 func (r *ListLogFilesRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *ListLogFilesRequest) RequestParams() map[string]string {
@@ -57,5 +59,5 @@ func (r *GenerateLogFileDownloadLinkRequest) ResourcePath() string {
 }
 
 func (r *GenerateLogFileDownloadLinkRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }

--- a/maintenance/request.go
+++ b/maintenance/request.go
@@ -109,7 +109,7 @@ func (r *DeleteRequest) ResourcePath() string {
 }
 
 func (r *DeleteRequest) Method() string {
-	return "DELETE"
+	return http.MethodDelete
 }
 
 type ListRequest struct {

--- a/maintenance/request.go
+++ b/maintenance/request.go
@@ -89,7 +89,7 @@ func (r *UpdateRequest) ResourcePath() string {
 }
 
 func (r *UpdateRequest) Method() string {
-	return "PUT"
+	return http.MethodPut
 }
 
 type DeleteRequest struct {

--- a/maintenance/request.go
+++ b/maintenance/request.go
@@ -1,9 +1,11 @@
 package maintenance
 
 import (
+	"net/http"
+	"time"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/pkg/errors"
-	"time"
 )
 
 type CreateRequest struct {
@@ -53,7 +55,7 @@ func (r *GetRequest) ResourcePath() string {
 }
 
 func (r *GetRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 type UpdateRequest struct {
@@ -128,7 +130,7 @@ func (r *ListRequest) ResourcePath() string {
 }
 
 func (r *ListRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 type CancelRequest struct {

--- a/maintenance/request.go
+++ b/maintenance/request.go
@@ -35,7 +35,7 @@ func (r *CreateRequest) ResourcePath() string {
 }
 
 func (r *CreateRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 type GetRequest struct {
@@ -150,7 +150,7 @@ func (r *CancelRequest) ResourcePath() string {
 }
 
 func (r *CancelRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 type Rule struct {

--- a/notification/notification_test.go
+++ b/notification/notification_test.go
@@ -113,7 +113,7 @@ func TestDeleteRequest_Validate(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, deleteRequest.ResourcePath(), "/v2/users/123/notification-rules/123/steps/1234")
-	assert.Equal(t, deleteRequest.Method(), "DELETE")
+	assert.Equal(t, deleteRequest.Method(), http.MethodDelete)
 
 }
 
@@ -451,7 +451,7 @@ func TestDeleteRuleRequest_Validate(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, deleteRequest.ResourcePath(), "/v2/users/123/notification-rules/123")
-	assert.Equal(t, deleteRequest.Method(), "DELETE")
+	assert.Equal(t, deleteRequest.Method(), http.MethodDelete)
 
 }
 

--- a/notification/notification_test.go
+++ b/notification/notification_test.go
@@ -1,10 +1,12 @@
 package notification
 
 import (
+	"net/http"
+	"testing"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/og"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestCreateRequest_Validate(t *testing.T) {
@@ -53,7 +55,7 @@ func TestGetRequest_Validate(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, getRequest.ResourcePath(), "/v2/users/123/notification-rules/123/steps/1234")
-	assert.Equal(t, getRequest.Method(), "GET")
+	assert.Equal(t, getRequest.Method(), http.MethodGet)
 
 }
 
@@ -130,7 +132,7 @@ func TestListRequest_Validate(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, listRequest.ResourcePath(), "/v2/users/123/notification-rules/1234/steps")
-	assert.Equal(t, listRequest.Method(), "GET")
+	assert.Equal(t, listRequest.Method(), http.MethodGet)
 
 }
 
@@ -318,7 +320,7 @@ func TestGetRuleRequest_Validate(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, getRequest.ResourcePath(), "/v2/users/123/notification-rules/123")
-	assert.Equal(t, getRequest.Method(), "GET")
+	assert.Equal(t, getRequest.Method(), http.MethodGet)
 
 }
 
@@ -464,7 +466,7 @@ func TestListRuleRequest_Validate(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, listRequest.ResourcePath(), "/v2/users/123/notification-rules")
-	assert.Equal(t, listRequest.Method(), "GET")
+	assert.Equal(t, listRequest.Method(), http.MethodGet)
 
 }
 

--- a/notification/notification_test.go
+++ b/notification/notification_test.go
@@ -90,7 +90,7 @@ func TestUpdateRequest_Validate(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, updateRequest.ResourcePath(), "/v2/users/123/notification-rules/123/steps/1234")
-	assert.Equal(t, updateRequest.Method(), "PATCH")
+	assert.Equal(t, updateRequest.Method(), http.MethodPatch)
 
 }
 
@@ -433,7 +433,7 @@ func TestUpdateRuleRequest_Validate(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, updateRuleRequest.ResourcePath(), "/v2/users/123/notification-rules/123")
-	assert.Equal(t, updateRuleRequest.Method(), "PATCH")
+	assert.Equal(t, updateRuleRequest.Method(), http.MethodPatch)
 }
 
 func TestDeleteRuleRequest_Validate(t *testing.T) {

--- a/notification/notification_test.go
+++ b/notification/notification_test.go
@@ -32,7 +32,7 @@ func TestCreateRequest_Validate(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, createRequest.ResourcePath(), "/v2/users/123/notification-rules/123/steps")
-	assert.Equal(t, createRequest.Method(), "POST")
+	assert.Equal(t, createRequest.Method(), http.MethodPost)
 
 }
 
@@ -155,7 +155,7 @@ func TestEnableRequest_Validate(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, enableRequest.ResourcePath(), "/v2/users/123/notification-rules/123/steps/1234/enable")
-	assert.Equal(t, enableRequest.Method(), "POST")
+	assert.Equal(t, enableRequest.Method(), http.MethodPost)
 
 }
 
@@ -178,7 +178,7 @@ func TestDisableRequest_Validate(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, disableRuleStepRequest.ResourcePath(), "/v2/users/123/notification-rules/123/steps/1234/disable")
-	assert.Equal(t, disableRuleStepRequest.Method(), "POST")
+	assert.Equal(t, disableRuleStepRequest.Method(), http.MethodPost)
 }
 
 func TestCreateRuleRequest_Validate(t *testing.T) {
@@ -301,7 +301,7 @@ func TestCreateRuleRequest_Validate(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, createRequest.ResourcePath(), "/v2/users/123/notification-rules")
-	assert.Equal(t, createRequest.Method(), "POST")
+	assert.Equal(t, createRequest.Method(), http.MethodPost)
 
 }
 
@@ -485,7 +485,7 @@ func TestEnableRuleRequest_Validate(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, enableRequest.ResourcePath(), "/v2/users/123/notification-rules/123/enable")
-	assert.Equal(t, enableRequest.Method(), "POST")
+	assert.Equal(t, enableRequest.Method(), http.MethodPost)
 
 }
 
@@ -504,7 +504,7 @@ func TestDisableRuleRequest_Validate(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, disableRuleRequest.ResourcePath(), "/v2/users/123/notification-rules/123/disable")
-	assert.Equal(t, disableRuleRequest.Method(), "POST")
+	assert.Equal(t, disableRuleRequest.Method(), http.MethodPost)
 }
 
 func TestCopyNotificationRulesRequest_Validate(t *testing.T) {
@@ -530,5 +530,5 @@ func TestCopyNotificationRulesRequest_Validate(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, copyNotificationRulesRequest.ResourcePath(), "/v2/users/123/notification-rules/copy-to")
-	assert.Equal(t, copyNotificationRulesRequest.Method(), "POST")
+	assert.Equal(t, copyNotificationRulesRequest.Method(), http.MethodPost)
 }

--- a/notification/request.go
+++ b/notification/request.go
@@ -1,6 +1,8 @@
 package notification
 
 import (
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/og"
 	"github.com/pkg/errors"
@@ -58,7 +60,7 @@ func (r *GetRuleStepRequest) ResourcePath() string {
 }
 
 func (r *GetRuleStepRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 type UpdateRuleStepRequest struct {
@@ -139,7 +141,7 @@ func (r *ListRuleStepsRequest) ResourcePath() string {
 }
 
 func (r *ListRuleStepsRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 type EnableRuleStepRequest struct {
@@ -284,7 +286,7 @@ func (r *GetRuleRequest) ResourcePath() string {
 }
 
 func (r *GetRuleRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 type UpdateRuleRequest struct {
@@ -393,7 +395,7 @@ func (r *ListRuleRequest) ResourcePath() string {
 }
 
 func (r *ListRuleRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 type EnableRuleRequest struct {

--- a/notification/request.go
+++ b/notification/request.go
@@ -94,7 +94,7 @@ func (r *UpdateRuleStepRequest) ResourcePath() string {
 }
 
 func (r *UpdateRuleStepRequest) Method() string {
-	return "PATCH"
+	return http.MethodPatch
 }
 
 type DeleteRuleStepRequest struct {
@@ -351,7 +351,7 @@ func (r *UpdateRuleRequest) ResourcePath() string {
 }
 
 func (r *UpdateRuleRequest) Method() string {
-	return "PATCH"
+	return http.MethodPatch
 }
 
 type DeleteRuleRequest struct {

--- a/notification/request.go
+++ b/notification/request.go
@@ -36,7 +36,7 @@ func (r *CreateRuleStepRequest) ResourcePath() string {
 }
 
 func (r *CreateRuleStepRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 type GetRuleStepRequest struct {
@@ -165,7 +165,7 @@ func (r *EnableRuleStepRequest) ResourcePath() string {
 }
 
 func (r *EnableRuleStepRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 type DisableRuleStepRequest struct {
@@ -189,7 +189,7 @@ func (r *DisableRuleStepRequest) ResourcePath() string {
 }
 
 func (r *DisableRuleStepRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 type CreateRuleRequest struct {
@@ -263,7 +263,7 @@ func (r *CreateRuleRequest) ResourcePath() string {
 }
 
 func (r *CreateRuleRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 type GetRuleRequest struct {
@@ -418,7 +418,7 @@ func (r *EnableRuleRequest) ResourcePath() string {
 }
 
 func (r *EnableRuleRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 type DisableRuleRequest struct {
@@ -441,7 +441,7 @@ func (r *DisableRuleRequest) ResourcePath() string {
 }
 
 func (r *DisableRuleRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 type CopyNotificationRulesRequest struct {
@@ -470,7 +470,7 @@ func (r *CopyNotificationRulesRequest) ResourcePath() string {
 }
 
 func (r *CopyNotificationRulesRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 func validateRuleIdentifier(userIdentifier string, ruleIdentifier string) error {

--- a/notification/request.go
+++ b/notification/request.go
@@ -118,7 +118,7 @@ func (r *DeleteRuleStepRequest) ResourcePath() string {
 }
 
 func (r *DeleteRuleStepRequest) Method() string {
-	return "DELETE"
+	return http.MethodDelete
 }
 
 type ListRuleStepsRequest struct {
@@ -374,7 +374,7 @@ func (r *DeleteRuleRequest) ResourcePath() string {
 }
 
 func (r *DeleteRuleRequest) Method() string {
-	return "DELETE"
+	return http.MethodDelete
 }
 
 type ListRuleRequest struct {

--- a/policy/request.go
+++ b/policy/request.go
@@ -248,7 +248,7 @@ func (r *UpdateAlertPolicyRequest) ResourcePath() string {
 }
 
 func (r *UpdateAlertPolicyRequest) Method() string {
-	return "PUT"
+	return http.MethodPut
 }
 
 type UpdateNotificationPolicyRequest struct {
@@ -312,7 +312,7 @@ func (r *UpdateNotificationPolicyRequest) RequestParams() map[string]string {
 }
 
 func (r *UpdateNotificationPolicyRequest) Method() string {
-	return "PUT"
+	return http.MethodPut
 }
 
 type DeletePolicyRequest struct {

--- a/policy/request.go
+++ b/policy/request.go
@@ -2,6 +2,8 @@ package policy
 
 import (
 	"errors"
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/alert"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/og"
@@ -157,7 +159,7 @@ func (r *GetAlertPolicyRequest) RequestParams() map[string]string {
 }
 
 func (r *GetAlertPolicyRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 type GetNotificationPolicyRequest struct {
@@ -190,7 +192,7 @@ func (r *GetNotificationPolicyRequest) RequestParams() map[string]string {
 }
 
 func (r *GetNotificationPolicyRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 type UpdateAlertPolicyRequest struct {
@@ -471,7 +473,7 @@ func (r *ListAlertPoliciesRequest) ResourcePath() string {
 }
 
 func (r *ListAlertPoliciesRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *ListAlertPoliciesRequest) RequestParams() map[string]string {
@@ -500,7 +502,7 @@ func (r *ListNotificationPoliciesRequest) ResourcePath() string {
 }
 
 func (r *ListNotificationPoliciesRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *ListNotificationPoliciesRequest) RequestParams() map[string]string {

--- a/policy/request.go
+++ b/policy/request.go
@@ -338,7 +338,7 @@ func (r *DeletePolicyRequest) ResourcePath() string {
 }
 
 func (r *DeletePolicyRequest) Method() string {
-	return "DELETE"
+	return http.MethodDelete
 }
 
 func (r *DeletePolicyRequest) RequestParams() map[string]string {

--- a/policy/request.go
+++ b/policy/request.go
@@ -77,7 +77,7 @@ func (r *CreateAlertPolicyRequest) ResourcePath() string {
 }
 
 func (r *CreateAlertPolicyRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 func (r *CreateNotificationPolicyRequest) Validate() error {
@@ -129,7 +129,7 @@ func (r *CreateNotificationPolicyRequest) RequestParams() map[string]string {
 }
 
 func (r *CreateNotificationPolicyRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 type GetAlertPolicyRequest struct {
@@ -373,7 +373,7 @@ func (r *DisablePolicyRequest) ResourcePath() string {
 }
 
 func (r *DisablePolicyRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 func (r *DisablePolicyRequest) RequestParams() map[string]string {
@@ -408,7 +408,7 @@ func (r *EnablePolicyRequest) ResourcePath() string {
 }
 
 func (r *EnablePolicyRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 func (r *EnablePolicyRequest) RequestParams() map[string]string {
@@ -447,7 +447,7 @@ func (r *ChangeOrderRequest) ResourcePath() string {
 }
 
 func (r *ChangeOrderRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 func (r *ChangeOrderRequest) RequestParams() map[string]string {

--- a/schedule/request.go
+++ b/schedule/request.go
@@ -38,7 +38,7 @@ func (r *CreateRequest) ResourcePath() string {
 }
 
 func (r *CreateRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 type GetRequest struct {
@@ -363,7 +363,7 @@ func (r *CreateRotationRequest) ResourcePath() string {
 }
 
 func (r *CreateRotationRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 func (r *CreateRotationRequest) RequestParams() map[string]string {

--- a/schedule/request.go
+++ b/schedule/request.go
@@ -1,11 +1,13 @@
 package schedule
 
 import (
+	"net/http"
+	"strconv"
+	"time"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/og"
 	"github.com/pkg/errors"
-	"strconv"
-	"time"
 )
 
 type Identifier uint32
@@ -59,7 +61,7 @@ func (r *GetRequest) ResourcePath() string {
 }
 
 func (r *GetRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *GetRequest) RequestParams() map[string]string {
@@ -172,7 +174,7 @@ func (r *ListRequest) ResourcePath() string {
 }
 
 func (r *ListRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *ListRequest) RequestParams() map[string]string {
@@ -216,7 +218,7 @@ func (r *GetTimelineRequest) ResourcePath() string {
 }
 
 func (r *GetTimelineRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *GetTimelineRequest) RequestParams() map[string]string {
@@ -273,7 +275,7 @@ func (r *ExportScheduleRequest) Validate() error {
 }
 
 func (r *ExportScheduleRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *ExportScheduleRequest) getFileName() string {
@@ -404,7 +406,7 @@ func (r *GetRotationRequest) ResourcePath() string {
 }
 
 func (r *GetRotationRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *GetRotationRequest) RequestParams() map[string]string {
@@ -531,7 +533,7 @@ func (r *ListRotationsRequest) ResourcePath() string {
 }
 
 func (r *ListRotationsRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *ListRotationsRequest) RequestParams() map[string]string {

--- a/schedule/request.go
+++ b/schedule/request.go
@@ -107,7 +107,7 @@ func (r *UpdateRequest) ResourcePath() string {
 }
 
 func (r *UpdateRequest) Method() string {
-	return "PATCH"
+	return http.MethodPatch
 }
 
 func (r *UpdateRequest) RequestParams() map[string]string {
@@ -450,7 +450,7 @@ func (r *UpdateRotationRequest) ResourcePath() string {
 }
 
 func (r *UpdateRotationRequest) Method() string {
-	return "PATCH"
+	return http.MethodPatch
 }
 
 func (r *UpdateRotationRequest) RequestParams() map[string]string {

--- a/schedule/request.go
+++ b/schedule/request.go
@@ -143,7 +143,7 @@ func (r *DeleteRequest) ResourcePath() string {
 }
 
 func (r *DeleteRequest) Method() string {
-	return "DELETE"
+	return http.MethodDelete
 }
 
 func (r *DeleteRequest) RequestParams() map[string]string {
@@ -494,7 +494,7 @@ func (r *DeleteRotationRequest) ResourcePath() string {
 }
 
 func (r *DeleteRotationRequest) Method() string {
-	return "DELETE"
+	return http.MethodDelete
 }
 
 func (r *DeleteRotationRequest) RequestParams() map[string]string {

--- a/schedule/schedule_override_request.go
+++ b/schedule/schedule_override_request.go
@@ -224,7 +224,7 @@ func (r *UpdateScheduleOverrideRequest) ResourcePath() string {
 }
 
 func (r *UpdateScheduleOverrideRequest) Method() string {
-	return "PUT"
+	return http.MethodPut
 }
 
 func (r *UpdateScheduleOverrideRequest) RequestParams() map[string]string {

--- a/schedule/schedule_override_request.go
+++ b/schedule/schedule_override_request.go
@@ -2,8 +2,10 @@ package schedule
 
 import (
 	"errors"
-	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
+	"net/http"
 	"time"
+
+	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 )
 
 type RotationIdentifier struct {
@@ -89,7 +91,7 @@ func (r *GetScheduleOverrideRequest) ResourcePath() string {
 }
 
 func (r *GetScheduleOverrideRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *GetScheduleOverrideRequest) RequestParams() map[string]string {
@@ -124,7 +126,7 @@ func (r *ListScheduleOverrideRequest) ResourcePath() string {
 }
 
 func (r *ListScheduleOverrideRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *ListScheduleOverrideRequest) RequestParams() map[string]string {

--- a/schedule/schedule_override_request.go
+++ b/schedule/schedule_override_request.go
@@ -167,7 +167,7 @@ func (r *DeleteScheduleOverrideRequest) ResourcePath() string {
 }
 
 func (r *DeleteScheduleOverrideRequest) Method() string {
-	return "DELETE"
+	return http.MethodDelete
 }
 
 func (r *DeleteScheduleOverrideRequest) RequestParams() map[string]string {

--- a/schedule/schedule_override_request.go
+++ b/schedule/schedule_override_request.go
@@ -50,7 +50,7 @@ func (r *CreateScheduleOverrideRequest) ResourcePath() string {
 }
 
 func (r *CreateScheduleOverrideRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 func (r *CreateScheduleOverrideRequest) RequestParams() map[string]string {

--- a/schedule/who_is_oncall_request.go
+++ b/schedule/who_is_oncall_request.go
@@ -1,8 +1,10 @@
 package schedule
 
 import (
-	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
+	"net/http"
 	"time"
+
+	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 )
 
 type GetOnCallsRequest struct {
@@ -22,7 +24,7 @@ func (r *GetOnCallsRequest) Validate() error {
 }
 
 func (r *GetOnCallsRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *GetOnCallsRequest) ResourcePath() string {
@@ -66,7 +68,7 @@ func (r *GetNextOnCallsRequest) Validate() error {
 }
 
 func (r *GetNextOnCallsRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *GetNextOnCallsRequest) ResourcePath() string {
@@ -108,7 +110,7 @@ func (r *ExportOnCallUserRequest) Validate() error {
 }
 
 func (r *ExportOnCallUserRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *ExportOnCallUserRequest) getFileName() string {

--- a/service/service_audience_template_request.go
+++ b/service/service_audience_template_request.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/og"
 	"github.com/pkg/errors"
@@ -24,7 +26,7 @@ func (r *GetAudienceTemplateRequest) ResourcePath() string {
 }
 
 func (r *GetAudienceTemplateRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 type UpdateAudienceTemplateRequest struct {

--- a/service/service_audience_template_request.go
+++ b/service/service_audience_template_request.go
@@ -63,7 +63,7 @@ func (r *UpdateAudienceTemplateRequest) ResourcePath() string {
 }
 
 func (r *UpdateAudienceTemplateRequest) Method() string {
-	return "PATCH"
+	return http.MethodPatch
 }
 
 type ResponderOfAudience struct {

--- a/service/service_audience_template_test.go
+++ b/service/service_audience_template_test.go
@@ -1,9 +1,11 @@
 package service
 
 import (
+	"net/http"
+	"testing"
+
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestBuildUpdateAudienceTemplateRequest_Validate(t *testing.T) {
@@ -60,5 +62,5 @@ func TestBuildGetAudienceTemplateRequest_Validate(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, request.ResourcePath(), "/v1/services/id/audience-templates")
-	assert.Equal(t, request.Method(), "GET")
+	assert.Equal(t, request.Method(), http.MethodGet)
 }

--- a/service/service_audience_template_test.go
+++ b/service/service_audience_template_test.go
@@ -48,7 +48,7 @@ func TestBuildUpdateAudienceTemplateRequest_Validate(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, request.ResourcePath(), "/v1/services/id/audience-templates")
-	assert.Equal(t, request.Method(), "PATCH")
+	assert.Equal(t, request.Method(), http.MethodPatch)
 }
 
 func TestBuildGetAudienceTemplateRequest_Validate(t *testing.T) {

--- a/service/service_incident_rule_request.go
+++ b/service/service_incident_rule_request.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/alert"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/og"
@@ -128,7 +130,7 @@ func (r *GetIncidentRulesRequest) ResourcePath() string {
 }
 
 func (r *GetIncidentRulesRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 type IncidentProperties struct {

--- a/service/service_incident_rule_request.go
+++ b/service/service_incident_rule_request.go
@@ -109,7 +109,7 @@ func (r *DeleteIncidentRuleRequest) ResourcePath() string {
 }
 
 func (r *DeleteIncidentRuleRequest) Method() string {
-	return "DELETE"
+	return http.MethodDelete
 }
 
 type GetIncidentRulesRequest struct {

--- a/service/service_incident_rule_request.go
+++ b/service/service_incident_rule_request.go
@@ -41,7 +41,7 @@ func (r *CreateIncidentRuleRequest) ResourcePath() string {
 }
 
 func (r *CreateIncidentRuleRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 type UpdateIncidentRuleRequest struct {

--- a/service/service_incident_rule_request.go
+++ b/service/service_incident_rule_request.go
@@ -82,7 +82,7 @@ func (r *UpdateIncidentRuleRequest) ResourcePath() string {
 }
 
 func (r *UpdateIncidentRuleRequest) Method() string {
-	return "PUT"
+	return http.MethodPut
 }
 
 type DeleteIncidentRuleRequest struct {

--- a/service/service_incident_rule_test.go
+++ b/service/service_incident_rule_test.go
@@ -56,7 +56,7 @@ func TestBuildCreateIncidentRuleRequest_Validate(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, request.ResourcePath(), "/v1/services/id/incident-rules")
-	assert.Equal(t, request.Method(), "POST")
+	assert.Equal(t, request.Method(), http.MethodPost)
 }
 
 func TestBuildUpdateIncidentRuleRequest_Validate(t *testing.T) {

--- a/service/service_incident_rule_test.go
+++ b/service/service_incident_rule_test.go
@@ -122,7 +122,7 @@ func TestBuildDeleteIncidentRuleRequest_Validate(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, request.ResourcePath(), "/v1/services/id/incident-rules/id")
-	assert.Equal(t, request.Method(), "DELETE")
+	assert.Equal(t, request.Method(), http.MethodDelete)
 }
 
 func TestBuildGetIncidentRuleRequest_Validate(t *testing.T) {

--- a/service/service_incident_rule_test.go
+++ b/service/service_incident_rule_test.go
@@ -1,11 +1,13 @@
 package service
 
 import (
+	"math/rand"
+	"net/http"
+	"testing"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/alert"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
-	"math/rand"
-	"testing"
 )
 
 func TestBuildCreateIncidentRuleRequest_Validate(t *testing.T) {
@@ -134,7 +136,7 @@ func TestBuildGetIncidentRuleRequest_Validate(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, request.ResourcePath(), "/v1/services/id/incident-rules")
-	assert.Equal(t, request.Method(), "GET")
+	assert.Equal(t, request.Method(), http.MethodGet)
 }
 
 func RandomString(n int) string {

--- a/service/service_incident_rule_test.go
+++ b/service/service_incident_rule_test.go
@@ -104,7 +104,7 @@ func TestBuildUpdateIncidentRuleRequest_Validate(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, request.ResourcePath(), "/v1/services/id/incident-rules/id")
-	assert.Equal(t, request.Method(), "PUT")
+	assert.Equal(t, request.Method(), http.MethodPut)
 }
 
 func TestBuildDeleteIncidentRuleRequest_Validate(t *testing.T) {

--- a/service/service_incident_template_request.go
+++ b/service/service_incident_template_request.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"net/http"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/pkg/errors"
 )
@@ -116,7 +118,7 @@ func (r *GetIncidentTemplatesRequest) ResourcePath() string {
 }
 
 func (r *GetIncidentTemplatesRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func validateIncidentTemplate(template IncidentTemplateRequest) error {

--- a/service/service_incident_template_request.go
+++ b/service/service_incident_template_request.go
@@ -32,7 +32,7 @@ func (r *CreateIncidentTemplateRequest) ResourcePath() string {
 }
 
 func (r *CreateIncidentTemplateRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 type UpdateIncidentTemplateRequest struct {

--- a/service/service_incident_template_request.go
+++ b/service/service_incident_template_request.go
@@ -97,7 +97,7 @@ func (r *DeleteIncidentTemplateRequest) ResourcePath() string {
 }
 
 func (r *DeleteIncidentTemplateRequest) Method() string {
-	return "DELETE"
+	return http.MethodDelete
 }
 
 type GetIncidentTemplatesRequest struct {

--- a/service/service_incident_template_request.go
+++ b/service/service_incident_template_request.go
@@ -70,7 +70,7 @@ func (r *UpdateIncidentTemplateRequest) ResourcePath() string {
 }
 
 func (r *UpdateIncidentTemplateRequest) Method() string {
-	return "PUT"
+	return http.MethodPut
 }
 
 type DeleteIncidentTemplateRequest struct {

--- a/service/service_incident_template_test.go
+++ b/service/service_incident_template_test.go
@@ -129,7 +129,7 @@ func TestBuildDeleteIncidentTemplateRequest_Validate(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, request.ResourcePath(), "/v1/services/id/incident-templates/id")
-	assert.Equal(t, request.Method(), "DELETE")
+	assert.Equal(t, request.Method(), http.MethodDelete)
 }
 
 func TestBuildGetIncidentTemplateRequest_Validate(t *testing.T) {

--- a/service/service_incident_template_test.go
+++ b/service/service_incident_template_test.go
@@ -1,10 +1,12 @@
 package service
 
 import (
+	"net/http"
+	"testing"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/alert"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestBuildCreateIncidentTemplateRequest_Validate(t *testing.T) {
@@ -141,5 +143,5 @@ func TestBuildGetIncidentTemplateRequest_Validate(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, request.ResourcePath(), "/v1/services/id/incident-templates")
-	assert.Equal(t, request.Method(), "GET")
+	assert.Equal(t, request.Method(), http.MethodGet)
 }

--- a/service/service_incident_template_test.go
+++ b/service/service_incident_template_test.go
@@ -59,7 +59,7 @@ func TestBuildCreateIncidentTemplateRequest_Validate(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, request.ResourcePath(), "/v1/services/id/incident-templates")
-	assert.Equal(t, request.Method(), "POST")
+	assert.Equal(t, request.Method(), http.MethodPost)
 }
 
 func TestBuildUpdateIncidentTemplateRequest_Validate(t *testing.T) {

--- a/service/service_incident_template_test.go
+++ b/service/service_incident_template_test.go
@@ -111,7 +111,7 @@ func TestBuildUpdateIncidentTemplateRequest_Validate(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, request.ResourcePath(), "/v1/services/id/incident-templates/id")
-	assert.Equal(t, request.Method(), "PUT")
+	assert.Equal(t, request.Method(), http.MethodPut)
 }
 
 func TestBuildDeleteIncidentTemplateRequest_Validate(t *testing.T) {

--- a/service/service_request.go
+++ b/service/service_request.go
@@ -62,7 +62,7 @@ func (r *UpdateRequest) ResourcePath() string {
 }
 
 func (r *UpdateRequest) Method() string {
-	return "PATCH"
+	return http.MethodPatch
 }
 
 type DeleteRequest struct {

--- a/service/service_request.go
+++ b/service/service_request.go
@@ -35,7 +35,7 @@ func (r *CreateRequest) ResourcePath() string {
 }
 
 func (r *CreateRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 type UpdateRequest struct {

--- a/service/service_request.go
+++ b/service/service_request.go
@@ -1,9 +1,11 @@
 package service
 
 import (
+	"net/http"
+	"strconv"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/pkg/errors"
-	"strconv"
 )
 
 type CreateRequest struct {
@@ -100,7 +102,7 @@ func (r *GetRequest) ResourcePath() string {
 }
 
 func (r *GetRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 type ListRequest struct {
@@ -118,7 +120,7 @@ func (r *ListRequest) ResourcePath() string {
 }
 
 func (r *ListRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *ListRequest) RequestParams() map[string]string {

--- a/service/service_request.go
+++ b/service/service_request.go
@@ -82,7 +82,7 @@ func (r *DeleteRequest) ResourcePath() string {
 }
 
 func (r *DeleteRequest) Method() string {
-	return "DELETE"
+	return http.MethodDelete
 }
 
 type GetRequest struct {

--- a/team/request.go
+++ b/team/request.go
@@ -83,7 +83,7 @@ func (r *DeleteTeamRequest) ResourcePath() string {
 }
 
 func (r *DeleteTeamRequest) Method() string {
-	return "DELETE"
+	return http.MethodDelete
 }
 
 func (r *DeleteTeamRequest) RequestParams() map[string]string {
@@ -422,7 +422,7 @@ func (r *DeleteTeamRoleRequest) ResourcePath() string {
 }
 
 func (r *DeleteTeamRoleRequest) Method() string {
-	return "DELETE"
+	return http.MethodDelete
 }
 
 func (r *DeleteTeamRoleRequest) RequestParams() map[string]string {
@@ -570,7 +570,7 @@ func (r *RemoveTeamMemberRequest) ResourcePath() string {
 }
 
 func (r *RemoveTeamMemberRequest) Method() string {
-	return "DELETE"
+	return http.MethodDelete
 }
 
 func (r *RemoveTeamMemberRequest) RequestParams() map[string]string {
@@ -811,7 +811,7 @@ func (r *DeleteRoutingRuleRequest) ResourcePath() string {
 }
 
 func (r *DeleteRoutingRuleRequest) Method() string {
-	return "DELETE"
+	return http.MethodDelete
 }
 
 func (r *DeleteRoutingRuleRequest) RequestParams() map[string]string {

--- a/team/request.go
+++ b/team/request.go
@@ -2,9 +2,11 @@ package team
 
 import (
 	"errors"
+	"net/http"
+	"strconv"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/og"
-	"strconv"
 )
 
 type Identifier uint32
@@ -58,7 +60,7 @@ func (r *ListTeamRequest) ResourcePath() string {
 }
 
 func (r *ListTeamRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 type DeleteTeamRequest struct {
@@ -117,7 +119,7 @@ func (r *GetTeamRequest) ResourcePath() string {
 }
 
 func (r *GetTeamRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *GetTeamRequest) RequestParams() map[string]string {
@@ -182,7 +184,7 @@ func (r *ListTeamLogsRequest) ResourcePath() string {
 }
 
 func (r *ListTeamLogsRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *ListTeamLogsRequest) RequestParams() map[string]string {
@@ -300,7 +302,7 @@ func (r *GetTeamRoleRequest) ResourcePath() string {
 }
 
 func (r *GetTeamRoleRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *GetTeamRoleRequest) RequestParams() map[string]string {
@@ -462,7 +464,7 @@ func (r *ListTeamRoleRequest) ResourcePath() string {
 }
 
 func (r *ListTeamRoleRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *ListTeamRoleRequest) RequestParams() map[string]string {
@@ -697,7 +699,7 @@ func (r *GetRoutingRuleRequest) ResourcePath() string {
 }
 
 func (r *GetRoutingRuleRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *GetRoutingRuleRequest) RequestParams() map[string]string {
@@ -847,7 +849,7 @@ func (r *ListRoutingRulesRequest) ResourcePath() string {
 }
 
 func (r *ListRoutingRulesRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *ListRoutingRulesRequest) RequestParams() map[string]string {

--- a/team/request.go
+++ b/team/request.go
@@ -156,7 +156,7 @@ func (r *UpdateTeamRequest) ResourcePath() string {
 }
 
 func (r *UpdateTeamRequest) Method() string {
-	return "PATCH"
+	return http.MethodPatch
 }
 
 type ListTeamLogsRequest struct {
@@ -364,7 +364,7 @@ func (r *UpdateTeamRoleRequest) ResourcePath() string {
 }
 
 func (r *UpdateTeamRoleRequest) Method() string {
-	return "PATCH"
+	return http.MethodPatch
 }
 
 func (r *UpdateTeamRoleRequest) RequestParams() map[string]string {
@@ -768,7 +768,7 @@ func (r *UpdateRoutingRuleRequest) ResourcePath() string {
 }
 
 func (r *UpdateRoutingRuleRequest) Method() string {
-	return "PATCH"
+	return http.MethodPatch
 }
 
 func (r *UpdateRoutingRuleRequest) RequestParams() map[string]string {

--- a/team/request.go
+++ b/team/request.go
@@ -42,7 +42,7 @@ func (r *CreateTeamRequest) ResourcePath() string {
 }
 
 func (r *CreateTeamRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 type ListTeamRequest struct {
@@ -248,7 +248,7 @@ func (r *CreateTeamRoleRequest) ResourcePath() string {
 }
 
 func (r *CreateTeamRoleRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 func (r *CreateTeamRoleRequest) RequestParams() map[string]string {
@@ -522,7 +522,7 @@ func (r *AddTeamMemberRequest) ResourcePath() string {
 }
 
 func (r *AddTeamMemberRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 func (r *AddTeamMemberRequest) RequestParams() map[string]string {
@@ -651,7 +651,7 @@ func (r *CreateRoutingRuleRequest) ResourcePath() string {
 }
 
 func (r *CreateRoutingRuleRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 func (r *CreateRoutingRuleRequest) RequestParams() map[string]string {
@@ -897,7 +897,7 @@ func (r *ChangeRoutingRuleOrderRequest) ResourcePath() string {
 }
 
 func (r *ChangeRoutingRuleOrderRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 func (r *ChangeRoutingRuleOrderRequest) RequestParams() map[string]string {

--- a/user/user_request.go
+++ b/user/user_request.go
@@ -74,7 +74,7 @@ func (r *CreateRequest) ResourcePath() string {
 }
 
 func (r *CreateRequest) Method() string {
-	return "POST"
+	return http.MethodPost
 }
 
 type GetRequest struct {

--- a/user/user_request.go
+++ b/user/user_request.go
@@ -1,9 +1,11 @@
 package user
 
 import (
+	"net/http"
+	"strconv"
+
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/pkg/errors"
-	"strconv"
 )
 
 type UserRoleRequest struct {
@@ -94,7 +96,7 @@ func (r *GetRequest) ResourcePath() string {
 }
 
 func (r *GetRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *GetRequest) RequestParams() map[string]string {
@@ -182,7 +184,7 @@ func (r *ListRequest) ResourcePath() string {
 }
 
 func (r *ListRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *ListRequest) RequestParams() map[string]string {
@@ -230,7 +232,7 @@ func (r *ListUserEscalationsRequest) ResourcePath() string {
 }
 
 func (r *ListUserEscalationsRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 type ListUserTeamsRequest struct {
@@ -251,7 +253,7 @@ func (r *ListUserTeamsRequest) ResourcePath() string {
 }
 
 func (r *ListUserTeamsRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 type ListUserForwardingRulesRequest struct {
@@ -272,7 +274,7 @@ func (r *ListUserForwardingRulesRequest) ResourcePath() string {
 }
 
 func (r *ListUserForwardingRulesRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 type ListUserSchedulesRequest struct {
@@ -293,7 +295,7 @@ func (r *ListUserSchedulesRequest) ResourcePath() string {
 }
 
 func (r *ListUserSchedulesRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 type GetSavedSearchRequest struct {
@@ -315,7 +317,7 @@ func (r *GetSavedSearchRequest) ResourcePath() string {
 }
 
 func (r *GetSavedSearchRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 func (r *GetSavedSearchRequest) RequestParams() map[string]string {
@@ -344,7 +346,7 @@ func (r *ListSavedSearchesRequest) ResourcePath() string {
 }
 
 func (r *ListSavedSearchesRequest) Method() string {
-	return "GET"
+	return http.MethodGet
 }
 
 type DeleteSavedSearchRequest struct {

--- a/user/user_request.go
+++ b/user/user_request.go
@@ -141,7 +141,7 @@ func (r *UpdateRequest) ResourcePath() string {
 }
 
 func (r *UpdateRequest) Method() string {
-	return "PATCH"
+	return http.MethodPatch
 }
 
 type DeleteRequest struct {

--- a/user/user_request.go
+++ b/user/user_request.go
@@ -162,7 +162,7 @@ func (r *DeleteRequest) ResourcePath() string {
 }
 
 func (r *DeleteRequest) Method() string {
-	return "DELETE"
+	return http.MethodDelete
 }
 
 type ListRequest struct {
@@ -368,7 +368,7 @@ func (r *DeleteSavedSearchRequest) ResourcePath() string {
 }
 
 func (r *DeleteSavedSearchRequest) Method() string {
-	return "DELETE"
+	return http.MethodDelete
 }
 
 func (r *DeleteSavedSearchRequest) RequestParams() map[string]string {


### PR DESCRIPTION
Hi,

I fixed here some trivial [goconst](https://github.com/jgautheron/goconst) issues, replacing HTTP methods strings with their corresponding constants. See [here](https://golang.org/pkg/net/http/#pkg-constants).

Do you use [golangci-lint](https://github.com/golangci/golangci-lint) or something similar internally, or would you be interested on integrating this here with some public CI like CircleCI?