### PR TITLE
Removing logging on the API key when a client is created

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -244,8 +244,7 @@ func NewOpsGenieClient(cfg *Config) (*OpsGenieClient, error) {
 }
 
 func printInfoLog(client *OpsGenieClient) {
-	client.Config.Logger.Infof("Client is configured with ApiKey: %s, ApiUrl: %s, LogLevel: %s, RetryMaxCount: %v",
-		client.Config.ApiKey,
+	client.Config.Logger.Infof("Client is configured with ApiUrl: %s, LogLevel: %s, RetryMaxCount: %v",
 		client.Config.OpsGenieAPIURL,
 		client.Config.Logger.GetLevel().String(),
 		client.RetryableClient.RetryMax)


### PR DESCRIPTION
Currently when a client is created it prints a log, this contains information about the API Key and other client details.

Ideally this wouldn't be logged at all and would be left up to the consuming application, but there are security implications by automatically logging the API key that is leaked into whatever log aggregation when the client is created, without anyway to disable this.