### PR TITLE
pass the teamID of CreateAlertPolicy to the API request when provided

### DIFF
--- a/policy/request.go
+++ b/policy/request.go
@@ -80,6 +80,15 @@ func (r *CreateAlertPolicyRequest) Method() string {
 	return http.MethodPost
 }
 
+func (r *CreateAlertPolicyRequest) RequestParams() map[string]string {
+	if r.TeamId == "" {
+		return nil
+	}
+	params := make(map[string]string)
+	params["teamId"] = r.TeamId
+	return params
+}
+
 func (r *CreateNotificationPolicyRequest) Validate() error {
 	err := ValidateMainFields(&r.MainFields)
 	if err != nil {


### PR DESCRIPTION
Hello, 

The CreateAlertPolicyRequest was missing the RequestParams function required to add a team ID as query parameter when creating a AlertPolicy.
This ensures that the TeamID parameter gets added to the request parameter when provided (just like the CreateNotificationPolicyRequest)

Kind Regards