### PR TITLE
Fix json unmarshall error when parsing the result data

### DIFF
--- a/alert/alert_consts.go
+++ b/alert/alert_consts.go
@@ -28,8 +28,8 @@ const (
 )
 
 type Report struct {
-	AckTime        int32  `json:"ackTime,omitempty"`
-	CloseTime      int32  `json:"closeTime,omitempty"`
+	AckTime        int64  `json:"ackTime,omitempty"`
+	CloseTime      int64  `json:"closeTime,omitempty"`
 	AcknowledgedBy string `json:"acknowledgedBy,omitempty"`
 	ClosedBy       string `json:"closedBy,omitempty"`
 }


### PR DESCRIPTION
When we do list alert request on an opsgenie team, and if the team has any alerts which is open for more than 24 days, List alert request would fail with the following error - 

`Response could not be parsed, json: cannot unmarshal number 2766703003 into Go struct field Report.ackTime of type int32`

This is due to when the Ack or Close timestamps become bigger enough and can't be stored in int32 types(A case when there is alert which is acked or closed only after 24 days)