### PR TITLE
Fixed misspelled DeDupicationActionAction…

### DIFF
--- a/policy/request.go
+++ b/policy/request.go
@@ -34,7 +34,7 @@ type CreateNotificationPolicyRequest struct {
 	MainFields
 	AutoRestartAction   *AutoRestartAction   `json:"autoRestartAction,omitempty"`
 	AutoCloseAction     *AutoCloseAction     `json:"autoCloseAction,omitempty"`
-	DeDuplicationAction *DeDuplicationAction `json:"deduplicationActionAction,omitempty"`
+	DeDuplicationAction *DeDuplicationAction `json:"deduplicationAction,omitempty"`
 	DelayAction         *DelayAction         `json:"delayAction,omitempty"`
 	Suppress            *bool                `json:"suppress,omitempty"`
 }
@@ -265,7 +265,7 @@ type UpdateNotificationPolicyRequest struct {
 	MainFields
 	AutoRestartAction   *AutoRestartAction   `json:"autoRestartAction,omitempty"`
 	AutoCloseAction     *AutoCloseAction     `json:"autoCloseAction,omitempty"`
-	DeDuplicationAction *DeDuplicationAction `json:"deduplicationActionAction,omitempty"`
+	DeDuplicationAction *DeDuplicationAction `json:"deduplicationAction,omitempty"`
 	DelayAction         *DelayAction         `json:"delayAction,omitempty"`
 	Suppress            *bool                `json:"suppress,omitempty"`
 	Id                  string

--- a/policy/result.go
+++ b/policy/result.go
@@ -38,7 +38,7 @@ type GetNotificationPolicyResult struct {
 	MainFields
 	AutoRestartAction         *AutoRestartAction   `json:"autoRestartAction,omitempty"`
 	AutoCloseAction           *AutoCloseAction     `json:"autoCloseAction,omitempty"`
-	DeDuplicationActionAction *DeDuplicationAction `json:"deduplicationActionAction,omitempty"`
+	DeDuplicationAction       *DeDuplicationAction `json:"deduplicationAction,omitempty"`
 	DelayAction               *DelayAction         `json:"delayAction,omitempty"`
 	Suppress                  bool                 `json:"suppress,omitempty"`
 }


### PR DESCRIPTION
 Fixed misspelled DeDupicationActionAction in policy/request.go and policy/result.go

result.go had inconsistent struct field DeDupicationActionAction vs DeDupicationAction in request.go.

I have fixed that.