### PR TITLE
Fixed misspelled json field name for notification

### DIFF
--- a/notification/request.go
+++ b/notification/request.go
@@ -201,7 +201,7 @@ type CreateRuleRequest struct {
 	NotificationTime []NotificationTimeType `json:"notificationTime,omitempty"`
 	TimeRestriction  *og.TimeRestriction    `json:"timeRestriction,omitempty"`
 	Schedules        []Schedule             `json:"schedules,omitempty"`
-	Steps            []*og.Step             `json:"step,omitempty"`
+	Steps            []*og.Step             `json:"steps,omitempty"`
 	Order            uint32                 `json:"order,omitempty"`
 	Repeat           *Repeat                `json:"repeat,omitempty"`
 	Enabled          *bool                  `json:"enabled,omitempty"`
@@ -297,7 +297,7 @@ type UpdateRuleRequest struct {
 	NotificationTime []NotificationTimeType `json:"notificationTime,omitempty"`
 	TimeRestriction  *og.TimeRestriction    `json:"timeRestriction,omitempty"`
 	Schedules        []Schedule             `json:"schedules,omitempty"`
-	Steps            []*og.Step             `json:"step,omitempty"`
+	Steps            []*og.Step             `json:"steps,omitempty"`
 	Order            uint32                 `json:"order,omitempty"`
 	Repeat           *Repeat                `json:"repeat,omitempty"`
 	Enabled          *bool                  `json:"enabled,omitempty"`


### PR DESCRIPTION
Fixed misspelled json field name for notification (CreateRuleRequest and UpdateRuleRequest)

With this bug it's not possible to use SDK to create steps in notification rule - this fixes it.