### PR TITLE
notification/result.go fixed json file for field Enabled in GetRuleRe…

### DIFF
--- a/notification/result.go
+++ b/notification/result.go
@@ -71,7 +71,7 @@ type GetRuleResult struct {
 	Name             string                 `json:"name,omitempty"`
 	ActionType       ActionType             `json:"actionType,omitempty"`
 	Order            uint32                 `json:"order,omitempty"`
-	Enabled          bool                   `json:"bool,omitempty"`
+	Enabled          bool                   `json:"enabled,omitempty"`
 	NotificationTime []NotificationTimeType `json:"notificationTime,omitempty"`
 	TimeRestriction  *og.TimeRestriction    `json:"timeRestriction,omitempty"`
 	Steps            []*StepResult          `json:"steps,omitempty"`


### PR DESCRIPTION
…sult

Before this fix, there was a json field mis-match resulting in SDK returning Enabled always as false.