### PR TITLE
Fix missing Order in RoutingRuleMeta struct

### DIFF
--- a/team/result.go
+++ b/team/result.go
@@ -18,6 +18,7 @@ type ListedTeams struct {
 type RoutingRuleMeta struct {
 	Id              string             `json:"id,omitempty"`
 	Name            string             `json:"name,omitempty"`
+	Order           int                `json:"order,omitempty"`
 	IsDefault       bool               `json:"isDefault,omitempty"`
 	Criteria        og.Criteria        `json:"criteria,omitempty"`
 	Timezone        string             `json:"timezone,omitempty"`


### PR DESCRIPTION
Add Order in RoutingRuleMeta struct because it is not returned while reading a team routing rule with SDK.