### PR TITLE
add criteria in notification.GetRuleResult

### DIFF
--- a/notification/result.go
+++ b/notification/result.go
@@ -70,6 +70,7 @@ type GetRuleResult struct {
 	Id               string                 `json:"id,omitempty"`
 	Name             string                 `json:"name,omitempty"`
 	ActionType       ActionType             `json:"actionType,omitempty"`
+	Criteria         *og.Filter             `json:"criteria,omitempty"`
 	Order            uint32                 `json:"order,omitempty"`
 	Enabled          bool                   `json:"enabled,omitempty"`
 	NotificationTime []NotificationTimeType `json:"notificationTime,omitempty"`


### PR DESCRIPTION
please add it soon as I was writing a validator for notification rules and without it, it is blocked.
I see this is returned in api response in curl. 
curl -X GET 'https://api.opsgenie.com/v2/users/<userid>/notification-rules/<notification-id>'
    --header 'Authorization: GenieKey <key-id>'