### PR TITLE
Added change-end-date endpoint for maintenance

### DIFF
--- a/maintenance/maintenance.go
+++ b/maintenance/maintenance.go
@@ -44,6 +44,15 @@ func (c *Client) Update(context context.Context, request *UpdateRequest) (*Updat
 	return result, nil
 }
 
+func (c *Client) ChangeEndDate(context context.Context, request *ChangeEndDateRequest) (*ChangeEndDateResult, error) {
+	result := &ChangeEndDateResult{}
+	err := c.client.Exec(context, request, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 func (c *Client) Delete(context context.Context, request *DeleteRequest) (*DeleteResult, error) {
 	result := &DeleteResult{}
 	err := c.client.Exec(context, request, result)

--- a/maintenance/maintenance_test.go
+++ b/maintenance/maintenance_test.go
@@ -74,6 +74,20 @@ func TestUpdateRequest_Validate(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestChangeEndDateRequest_Validate(t *testing.T) {
+	now := time.Now()
+	after := now.Add(time.Minute)
+	request := &ChangeEndDateRequest{}
+	err := request.Validate()
+	assert.Equal(t, err.Error(), errors.New("Maintenance ID cannot be blank.").Error())
+	request.Id = "e14dda76-488e-4e98-a1c7-78cda1900e27"
+	err = request.Validate()
+	assert.Equal(t, err.Error(), errors.New("Maintenance End Date cannot be blank.").Error())
+	request.EndDate = &after
+	err = request.Validate()
+	assert.Nil(t, err)
+}
+
 func TestDeleteRequest_Validate(t *testing.T) {
 	request := &DeleteRequest{}
 	err := request.Validate()

--- a/maintenance/request.go
+++ b/maintenance/request.go
@@ -92,6 +92,30 @@ func (r *UpdateRequest) Method() string {
 	return http.MethodPut
 }
 
+type ChangeEndDateRequest struct {
+	client.BaseRequest
+	Id      string
+	EndDate *time.Time `json:"endDate"`
+}
+
+func (r *ChangeEndDateRequest) Validate() error {
+	if r.Id == "" {
+		return errors.New("Maintenance ID cannot be blank.")
+	}
+	if r.EndDate == nil {
+		return errors.New("Maintenance End Date cannot be blank.")
+	}
+	return nil
+}
+
+func (r *ChangeEndDateRequest) ResourcePath() string {
+	return "/v1/maintenance/" + r.Id + "/change-end-date"
+}
+
+func (r *ChangeEndDateRequest) Method() string {
+	return http.MethodPost
+}
+
 type DeleteRequest struct {
 	client.BaseRequest
 	Id string

--- a/maintenance/result.go
+++ b/maintenance/result.go
@@ -19,6 +19,11 @@ type UpdateResult struct {
 	Maintenance
 }
 
+type ChangeEndDateResult struct {
+	client.ResultMetadata
+	Maintenance
+}
+
 type GetResult struct {
 	client.ResultMetadata
 	Id          string `json:"id"`


### PR DESCRIPTION
This pr fixes https://github.com/opsgenie/opsgenie-go-sdk-v2/issues/38