### PR TITLE
Client.UpdateIntegrationActions was supposed to send filter.conditionMatchType, was sending filter.type instead

### DIFF
--- a/integration/request.go
+++ b/integration/request.go
@@ -256,7 +256,7 @@ func (r *GetIntegrationActionsRequest) Method() string {
 	return http.MethodGet
 }
 
-type IntegrationActionFilter struct {
+type Filter struct {
        ConditionMatchType og.ConditionMatchType `json:"conditionMatchType,omitempty"`
        Conditions         []og.Condition        `json:"conditions,omitempty"`
 }
@@ -270,7 +270,7 @@ type CreateIntegrationActionsRequest struct {
 	Order                            int               `json:"order,omitempty"`
 	User                             string            `json:"user,omitempty"`
 	Note                             string            `json:"note,omitempty"`
-	Filter                           *IntegrationActionFilter        `json:"filter,omitempty"`
+	Filter                           *Filter           `json:"filter,omitempty"`
 	Source                           string            `json:"source,omitempty"`
 	Message                          string            `json:"message,omitempty"`
 	Description                      string            `json:"description,omitempty"`
@@ -334,7 +334,7 @@ type IntegrationAction struct {
 	Order                            int               `json:"order,omitempty"`
 	User                             string            `json:"user,omitempty"`
 	Note                             string            `json:"note,omitempty"`
-	Filter                           *IntegrationActionFilter        `json:"filter,omitempty"`
+	Filter                           *Filter           `json:"filter,omitempty"`
 	Source                           string            `json:"source,omitempty"`
 	Message                          string            `json:"message,omitempty"`
 	Description                      string            `json:"description,omitempty"`

--- a/integration/request.go
+++ b/integration/request.go
@@ -256,6 +256,11 @@ func (r *GetIntegrationActionsRequest) Method() string {
 	return http.MethodGet
 }
 
+type IntegrationActionFilter struct {
+       ConditionMatchType og.ConditionMatchType `json:"conditionMatchType,omitempty"`
+       Conditions         []og.Condition        `json:"conditions,omitempty"`
+}
+
 type CreateIntegrationActionsRequest struct {
 	client.BaseRequest
 	Id                               string
@@ -265,7 +270,7 @@ type CreateIntegrationActionsRequest struct {
 	Order                            int               `json:"order,omitempty"`
 	User                             string            `json:"user,omitempty"`
 	Note                             string            `json:"note,omitempty"`
-	Filter                           *og.IntegrationActionFilter        `json:"filter,omitempty"`
+	Filter                           *IntegrationActionFilter        `json:"filter,omitempty"`
 	Source                           string            `json:"source,omitempty"`
 	Message                          string            `json:"message,omitempty"`
 	Description                      string            `json:"description,omitempty"`
@@ -329,7 +334,7 @@ type IntegrationAction struct {
 	Order                            int               `json:"order,omitempty"`
 	User                             string            `json:"user,omitempty"`
 	Note                             string            `json:"note,omitempty"`
-	Filter                           *og.IntegrationActionFilter        `json:"filter,omitempty"`
+	Filter                           *IntegrationActionFilter        `json:"filter,omitempty"`
 	Source                           string            `json:"source,omitempty"`
 	Message                          string            `json:"message,omitempty"`
 	Description                      string            `json:"description,omitempty"`

--- a/integration/request.go
+++ b/integration/request.go
@@ -265,7 +265,7 @@ type CreateIntegrationActionsRequest struct {
 	Order                            int               `json:"order,omitempty"`
 	User                             string            `json:"user,omitempty"`
 	Note                             string            `json:"note,omitempty"`
-	Filter                           *og.Filter        `json:"filter,omitempty"`
+	Filter                           *og.IntegrationActionFilter        `json:"filter,omitempty"`
 	Source                           string            `json:"source,omitempty"`
 	Message                          string            `json:"message,omitempty"`
 	Description                      string            `json:"description,omitempty"`
@@ -297,7 +297,7 @@ func (r *CreateIntegrationActionsRequest) Validate() error {
 		if err != nil {
 			return err
 		}
-		err = og.ValidateFilter(*r.Filter)
+		err = og.ValidateFilter(og.Filter(*r.Filter))
 		if err != nil {
 			return err
 		}
@@ -329,7 +329,7 @@ type IntegrationAction struct {
 	Order                            int               `json:"order,omitempty"`
 	User                             string            `json:"user,omitempty"`
 	Note                             string            `json:"note,omitempty"`
-	Filter                           *og.Filter        `json:"filter,omitempty"`
+	Filter                           *og.IntegrationActionFilter        `json:"filter,omitempty"`
 	Source                           string            `json:"source,omitempty"`
 	Message                          string            `json:"message,omitempty"`
 	Description                      string            `json:"description,omitempty"`
@@ -379,7 +379,7 @@ func validateActions(actions []IntegrationAction) error {
 			if err != nil {
 				return err
 			}
-			err = og.ValidateFilter(*r.Filter)
+			err = og.ValidateFilter(og.Filter(*r.Filter))
 			if err != nil {
 				return err
 			}

--- a/og/entity.go
+++ b/og/entity.go
@@ -316,6 +316,11 @@ type Filter struct {
 	Conditions         []Condition        `json:"conditions,omitempty"`
 }
 
+type IntegrationActionFilter struct {
+	ConditionMatchType ConditionMatchType `json:"conditionMatchType,omitempty"`
+	Conditions         []Condition        `json:"conditions,omitempty"`
+}
+
 type Condition struct {
 	Field         ConditionFieldType `json:"field,omitempty"`
 	IsNot         *bool              `json:"not,omitempty"`

--- a/og/entity.go
+++ b/og/entity.go
@@ -316,11 +316,6 @@ type Filter struct {
 	Conditions         []Condition        `json:"conditions,omitempty"`
 }
 
-type IntegrationActionFilter struct {
-	ConditionMatchType ConditionMatchType `json:"conditionMatchType,omitempty"`
-	Conditions         []Condition        `json:"conditions,omitempty"`
-}
-
 type Condition struct {
 	Field         ConditionFieldType `json:"field,omitempty"`
 	IsNot         *bool              `json:"not,omitempty"`


### PR DESCRIPTION
Change in JSON serialized field name for filter.type in UpdateIntegrationAction API

Changed:
* og.Filter duplicated as integration.Filter - The json-tag is updated for the
  type field, to serialize as "conditionMatchType" key-name as per Integration API docs
* ValidateFilter() still works with the new type, typecasting to og.Filter is required 
* IntegrationAction.Filter type is updated to integration.Filter

Due to:
* client.UpdateAllActions was not working as expected due to missing conditionMatchType field
   The filter conditions were defaulting to type=match-all, conditions=[]