### PR TITLE
Adding email specific fields to ConditionFieldType

### DIFF
--- a/notification/notification_test.go
+++ b/notification/notification_test.go
@@ -254,7 +254,7 @@ func TestCreateRuleRequest_Validate(t *testing.T) {
 	conditions[0] = og.Condition{Operation: og.Contains}
 	createRequest.Criteria = &og.Criteria{CriteriaType: og.MatchAnyCondition, Conditions: conditions}
 	err = createRequest.Validate()
-	assert.Equal(t, err.Error(), errors.New("condition field should be one of message, alias, description, source, entity, tags, actions, details, extra-properties, recipients, teams or priority").Error())
+	assert.Equal(t, err.Error(), errors.New("condition field should be one of message, alias, description, source, entity, tags, actions, details, extra-properties, recipients, teams, priority, conversationSubject, from_address, from_name or subject").Error())
 
 	conditions[0] = og.Condition{Field: og.Alias, Operation: "a"}
 	createRequest.Criteria = &og.Criteria{CriteriaType: og.MatchAnyCondition, Conditions: conditions}
@@ -386,7 +386,7 @@ func TestUpdateRuleRequest_Validate(t *testing.T) {
 	conditions[0] = og.Condition{Operation: og.Contains}
 	updateRuleRequest.Criteria = &og.Criteria{CriteriaType: og.MatchAnyCondition, Conditions: conditions}
 	err = updateRuleRequest.Validate()
-	assert.Equal(t, err.Error(), errors.New("condition field should be one of message, alias, description, source, entity, tags, actions, details, extra-properties, recipients, teams or priority").Error())
+	assert.Equal(t, err.Error(), errors.New("condition field should be one of message, alias, description, source, entity, tags, actions, details, extra-properties, recipients, teams, priority, conversationSubject, from_address, from_name or subject").Error())
 
 	conditions[0] = og.Condition{Field: og.Alias, Operation: "a"}
 	updateRuleRequest.Criteria = &og.Criteria{CriteriaType: og.MatchAnyCondition, Conditions: conditions}

--- a/og/entity.go
+++ b/og/entity.go
@@ -141,10 +141,10 @@ func ValidateConditions(conditions []Condition) error {
 			return errors.New("condition key is only valid for extra-properties field")
 		}
 		switch condition.Field {
-		case Message, Alias, Description, Source, Entity, Tags, Actions, Details, ExtraProperties, Recipients, Teams, Priority:
+		case Message, Alias, Description, Source, Entity, Tags, Actions, Details, ExtraProperties, Recipients, Teams, Priority, ConversationSub, FromAddress, FromName, Subject:
 			break
 		default:
-			return errors.New("condition field should be one of message, alias, description, source, entity, tags, actions, details, extra-properties, recipients, teams or priority")
+			return errors.New("condition field should be one of message, alias, description, source, entity, tags, actions, details, extra-properties, recipients, teams, priority, conversationSubject, from_address, from_name or subject")
 		}
 		switch condition.Field {
 		case Actions, Tags, Recipients:
@@ -270,6 +270,10 @@ const (
 	Recipients      ConditionFieldType = "recipients"
 	Teams           ConditionFieldType = "teams"
 	Priority        ConditionFieldType = "priority"
+	ConversationSub ConditionFieldType = "conversationSubject"
+	FromAddress     ConditionFieldType = "from_address"
+	FromName        ConditionFieldType = "from_name"
+	Subject         ConditionFieldType = "subject"
 
 	Matches                ConditionOperation = "matches"
 	Contains               ConditionOperation = "contains"

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -45,7 +45,7 @@ func TestCreateAlertPolicy_Validate(t *testing.T) {
 		},
 	}
 	err = req.Validate()
-	assert.Equal(t, err.Error(), errors.New("condition field should be one of message, alias, description, source, entity, tags, actions, details, extra-properties, recipients, teams or priority").Error())
+	assert.Equal(t, err.Error(), errors.New("condition field should be one of message, alias, description, source, entity, tags, actions, details, extra-properties, recipients, teams, priority, conversationSubject, from_address, from_name or subject").Error())
 
 	req.Filter.Conditions = []og.Condition{
 		{

--- a/team/team_test.go
+++ b/team/team_test.go
@@ -122,7 +122,7 @@ func TestCreateRoutingRuleRequest_Validate(t *testing.T) {
 		},
 	}
 	err = createRoutingRuleRequest.Validate()
-	assert.Equal(t, err.Error(), errors.New("condition field should be one of message, alias, description, source, entity, tags, actions, details, extra-properties, recipients, teams or priority").Error())
+	assert.Equal(t, err.Error(), errors.New("condition field should be one of message, alias, description, source, entity, tags, actions, details, extra-properties, recipients, teams, priority, conversationSubject, from_address, from_name or subject").Error())
 
 	createRoutingRuleRequest.Criteria.Conditions = []og.Condition{
 		{


### PR DESCRIPTION
Currently it is not possible to programatically create filter actions
for email integrations since ValidateConditions is not aware of the
new field names.