### PR TITLE
integration/result: ActionsResult to return IntegrationAction slices

### DIFF
--- a/integration/result.go
+++ b/integration/result.go
@@ -63,11 +63,11 @@ type AuthenticateResult struct {
 type ActionsResult struct {
 	client.ResultMetadata
 	Parent      ParentIntegration   `json:"_parent"`
-	Ignore      []IgnoreAction      `json:"ignore"`
-	Create      []CreateAction      `json:"create"`
-	Close       []CloseAction       `json:"close"`
-	Acknowledge []AcknowledgeAction `json:"acknowledge"`
-	AddNote     []AddNoteAction     `json:"addNote"`
+	Ignore      []IntegrationAction `json:"ignore"`
+	Create      []IntegrationAction `json:"create"`
+	Close       []IntegrationAction `json:"close"`
+	Acknowledge []IntegrationAction `json:"acknowledge"`
+	AddNote     []IntegrationAction `json:"addNote"`
 }
 
 type ParentIntegration struct {


### PR DESCRIPTION
Modifying integration action Result to return same type as action Request

Current issue:
* UpdateAllIntegrationActionsRequest accepts slices of IntegrationAction's separately for each action type
* However, GetActions() returns an ActionResult that consists of IgnoreAction, CreateAction, CloseAction, etc which do not typecast to IntegrationAction type

This patch would harmonize the request/result to use the same datatype. Avoids unnecessary handling of special cases in downstream projects.

Affects:
* Downstream projects would have to replace CreateAction/CloseAction/... with IntegrationAction, the field names would remain the same