### PR TITLE
Support service tags on creation.

### DIFF
--- a/service/service_request.go
+++ b/service/service_request.go
@@ -14,6 +14,7 @@ type CreateRequest struct {
 	TeamId      string     `json:"teamId"`
 	Description string     `json:"description,omitempty"`
 	Visibility  Visibility `json:"visibility,omitempty"`
+	Tags        []string   `json:"tags,omitempty"`
 }
 
 func (r *CreateRequest) Validate() error {

--- a/service/service_result.go
+++ b/service/service_result.go
@@ -8,6 +8,7 @@ type Service struct {
 	Description string     `json:"description"`
 	Visibility  Visibility `json:"visibility"`
 	TeamId      string     `json:"teamId"`
+	Tags        []string   `json:"tags,omitempty"`
 }
 
 type CreateResult struct {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -21,6 +21,9 @@ func TestCreateRequest_Validate(t *testing.T) {
 	request.Visibility = OpsgenieUsers
 	err = request.Validate()
 	assert.Nil(t, err)
+	request.Tags = []string{"foo", "bar"}
+	err = request.Validate()
+	assert.Nil(t, err)
 }
 
 func TestUpdateRequest_Validate(t *testing.T) {


### PR DESCRIPTION
The API doesn't expose updating tags yet: https://docs.opsgenie.com/docs/service-api#update-service

This is needed for https://github.com/opsgenie/terraform-provider-opsgenie/issues/144 and https://github.com/opsgenie/terraform-provider-opsgenie/pull/149

I'm looking for suggestions for the tests!