### PR TITLE
Fix Deduplication Variable

### DIFF
--- a/policy/request.go
+++ b/policy/request.go
@@ -34,7 +34,7 @@ type CreateNotificationPolicyRequest struct {
 	MainFields
 	AutoRestartAction   *AutoRestartAction   `json:"autoRestartAction,omitempty"`
 	AutoCloseAction     *AutoCloseAction     `json:"autoCloseAction,omitempty"`
-	DeDuplicationAction *DeDuplicationAction `json:"deduplicationActionAction,omitempty"`
+	DeDuplicationAction *DeDuplicationAction `json:"deduplicationAction,omitempty"`
 	DelayAction         *DelayAction         `json:"delayAction,omitempty"`
 	Suppress            *bool                `json:"suppress,omitempty"`
 }
@@ -546,7 +546,7 @@ type AutoCloseAction struct {
 }
 
 type DeDuplicationAction struct {
-	DeDuplicationActionType DeDuplicationActionType `json:"deduplicationType,omitempty"`
+	DeDuplicationActionType DeDuplicationActionType `json:"deduplicationActionType,omitempty"`
 	Duration                *Duration               `json:"duration,omitempty"`
 	Count                   int                     `json:"count,omitempty"`
 }


### PR DESCRIPTION
Fixes an issue where the opsgenie api rejects the call due to incorrect variable name, returning:
```
ERRO[2020-11-30T11:21:37.457721+01:00] Error occurred with Status code: 422, Message: No action specified, Took: 0.013000, RequestId: 
```