### PR TITLE
Updating Policy Action to accept De Duplication

### DIFF
--- a/policy/request.go
+++ b/policy/request.go
@@ -34,7 +34,7 @@ type CreateNotificationPolicyRequest struct {
 	MainFields
 	AutoRestartAction   *AutoRestartAction   `json:"autoRestartAction,omitempty"`
 	AutoCloseAction     *AutoCloseAction     `json:"autoCloseAction,omitempty"`
-	DeDuplicationAction *DeDuplicationAction `json:"deduplicationActionAction,omitempty"`
+	DeDuplicationAction *DeDuplicationAction `json:"deduplicationAction,omitempty"`
 	DelayAction         *DelayAction         `json:"delayAction,omitempty"`
 	Suppress            *bool                `json:"suppress,omitempty"`
 }
@@ -271,7 +271,7 @@ type UpdateNotificationPolicyRequest struct {
 	MainFields
 	AutoRestartAction   *AutoRestartAction   `json:"autoRestartAction,omitempty"`
 	AutoCloseAction     *AutoCloseAction     `json:"autoCloseAction,omitempty"`
-	DeDuplicationAction *DeDuplicationAction `json:"deduplicationActionAction,omitempty"`
+	DeDuplicationAction *DeDuplicationAction `json:"deduplicationAction,omitempty"`
 	DelayAction         *DelayAction         `json:"delayAction,omitempty"`
 	Suppress            *bool                `json:"suppress,omitempty"`
 	Id                  string
@@ -546,7 +546,7 @@ type AutoCloseAction struct {
 }
 
 type DeDuplicationAction struct {
-	DeDuplicationActionType DeDuplicationActionType `json:"deduplicationType,omitempty"`
+	DeDuplicationActionType DeDuplicationActionType `json:"deduplicationActionType,omitempty"`
 	Duration                *Duration               `json:"duration,omitempty"`
 	Count                   int                     `json:"count,omitempty"`
 }


### PR DESCRIPTION
Updated the request.go of policy package. This removes minor mistakes in de duplication action of notification policy.