### PR TITLE
Fixing Get Notification Policy with DeDuplication Action

### DIFF
--- a/policy/result.go
+++ b/policy/result.go
@@ -38,7 +38,7 @@ type GetNotificationPolicyResult struct {
 	MainFields
 	AutoRestartAction         *AutoRestartAction   `json:"autoRestartAction,omitempty"`
 	AutoCloseAction           *AutoCloseAction     `json:"autoCloseAction,omitempty"`
-	DeDuplicationActionAction *DeDuplicationAction `json:"deduplicationActionAction,omitempty"`
+	DeDuplicationAction 	  *DeDuplicationAction `json:"deduplicationAction,omitempty"`
 	DelayAction               *DelayAction         `json:"delayAction,omitempty"`
 	Suppress                  bool                 `json:"suppress,omitempty"`
 }


### PR DESCRIPTION
Earlier commit updated the request object. This PR updated result object to start taking "deduplicationAction" from result json