### PR TITLE
Add OwnerTeamID field to Alert and fix lastOccuredAt typo

### DIFF
--- a/alert/result.go
+++ b/alert/result.go
@@ -27,6 +27,7 @@ type Alert struct {
 	Responders     []Responder `json:"responders"`
 	Integration    Integration `json:"integration,omitempty"`
 	Report         Report      `json:"report,omitempty"`
+	OwnerTeamID    string      `json:"ownerTeamId,omitempty"`
 }
 
 type Integration struct {

--- a/alert/result.go
+++ b/alert/result.go
@@ -18,7 +18,7 @@ type Alert struct {
 	Snoozed        bool        `json:"snoozed,omitempty"`
 	SnoozedUntil   time.Time   `json:"snoozedUntil,omitempty"`
 	Count          int         `json:"count,omitempty"`
-	LastOccurredAt time.Time   `json:"lastOccuredAt,omitempty"`
+	LastOccurredAt time.Time   `json:"lastOccurredAt,omitempty"`
 	CreatedAt      time.Time   `json:"createdAt,omitempty"`
 	UpdatedAt      time.Time   `json:"updatedAt,omitempty"`
 	Source         string      `json:"source,omitempty"`


### PR DESCRIPTION
This field is omitted from the upstream repo, yet is supported by
Atlassian.

I raised
https://getsupport.atlassian.com/servicedesk/customer/portal/45/OGSP-74633

I can provide the equivalent PRs to your Python and Ruby SDKs if required.