### PR TITLE
Change Json field name to description in AlertPolicy

### DIFF
--- a/policy/request.go
+++ b/policy/request.go
@@ -15,7 +15,7 @@ type CreateAlertPolicyRequest struct {
 	Message                  string             `json:"message,omitempty"`
 	Continue                 *bool              `json:"continue,omitempty"`
 	Alias                    string             `json:"alias,omitempty"`
-	AlertDescription         string             `json:"alertDescription,omitempty"`
+	AlertDescription         string             `json:"description,omitempty"`
 	Entity                   string             `json:"entity,omitempty"`
 	Source                   string             `json:"source,omitempty"`
 	IgnoreOriginalDetails    *bool              `json:"ignoreOriginalDetails,omitempty"`
@@ -257,9 +257,9 @@ func (r *UpdateAlertPolicyRequest) ResourcePath() string {
 }
 
 func (r *UpdateAlertPolicyRequest) RequestParams() map[string]string {
-        params := make(map[string]string)
-        params["teamId"] = r.TeamId
-        return params
+	params := make(map[string]string)
+	params["teamId"] = r.TeamId
+	return params
 }
 
 func (r *UpdateAlertPolicyRequest) Method() string {

--- a/policy/result.go
+++ b/policy/result.go
@@ -19,7 +19,7 @@ type GetAlertPolicyResult struct {
 	Message                  string             `json:"message"`
 	Continue                 bool               `json:"continue,omitempty"`
 	Alias                    string             `json:"alias,omitempty"`
-	AlertDescription         string             `json:"alertDescription,omitempty"`
+	AlertDescription         string             `json:"description,omitempty"`
 	Entity                   string             `json:"entity,omitempty"`
 	Source                   string             `json:"source,omitempty"`
 	IgnoreOriginalDetails    bool               `json:"ignoreOriginalDetails,omitempty"`
@@ -36,11 +36,11 @@ type GetAlertPolicyResult struct {
 type GetNotificationPolicyResult struct {
 	client.ResultMetadata
 	MainFields
-	AutoRestartAction         *AutoRestartAction   `json:"autoRestartAction,omitempty"`
-	AutoCloseAction           *AutoCloseAction     `json:"autoCloseAction,omitempty"`
-	DeDuplicationAction 	  *DeDuplicationAction `json:"deduplicationAction,omitempty"`
-	DelayAction               *DelayAction         `json:"delayAction,omitempty"`
-	Suppress                  bool                 `json:"suppress,omitempty"`
+	AutoRestartAction   *AutoRestartAction   `json:"autoRestartAction,omitempty"`
+	AutoCloseAction     *AutoCloseAction     `json:"autoCloseAction,omitempty"`
+	DeDuplicationAction *DeDuplicationAction `json:"deduplicationAction,omitempty"`
+	DelayAction         *DelayAction         `json:"delayAction,omitempty"`
+	Suppress            bool                 `json:"suppress,omitempty"`
 }
 
 type PolicyResult struct {


### PR DESCRIPTION
Update json mapping for alertDescription field. Also fixes the followings:
https://github.com/opsgenie/terraform-provider-opsgenie/pull/206
https://github.com/opsgenie/terraform-provider-opsgenie/issues/202

Signed-off-by: Fahri YARDIMCI 