### PR TITLE
Add SendViaOEC and SendViaMarid to API Integration Request

### DIFF
--- a/integration/request.go
+++ b/integration/request.go
@@ -51,6 +51,8 @@ type APIBasedIntegrationRequest struct {
 	AllowWriteAccess            *bool         `json:"allowWriteAccess"`
 	IgnoreRespondersFromPayload *bool         `json:"ignoreRespondersFromPayload"`
 	SuppressNotifications       *bool         `json:"suppressNotifications"`
+	SendViaOEC                  *bool         `json:"sendViaOEC,omitempty"`
+	SendViaMarid                *bool         `json:"sendViaMarid,omitempty"`
 	OwnerTeam                   *og.OwnerTeam `json:"ownerTeam,omitempty"`
 	Responders                  []Responder   `json:"responders,omitempty"`
 }

--- a/integration/result.go
+++ b/integration/result.go
@@ -166,8 +166,8 @@ const (
 )
 
 type Responder struct {
-	Type     ResponderType `json:"type, omitempty"`
+	Type     ResponderType `json:"type,omitempty"`
 	Name     string        `json:"name,omitempty"`
 	Id       string        `json:"id,omitempty"`
-	Username string        `json:"username, omitempty"`
+	Username string        `json:"username,omitempty"`
 }


### PR DESCRIPTION
I opened an issue on terraform-provider-opsgenie because I was unable to create an integration with the type "Zabbix" as it was missing the bool _sendViaOEC_ or _sendViaMarid_ as required by the API.

I tested the changes by adding the required *bool to the APIBasedIntegrationRequest struct in the SDK, and then adding the fields to createApiIntegration on the Terraform Provider.

I was successfully able to compile and create a Zabbix integration with the provider on my local machine.

I also removed two apparently erroneous spaces in result.go JSON (my system was complaining about them).

Please can you review and approve my change?