### PR TITLE
fix #100: allow config to receive FieldLogger interface

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -174,19 +174,26 @@ func setConfiguration(opsGenieClient *OpsGenieClient, cfg *Config) {
 }
 
 func setLogger(conf *Config) {
-	if conf.Logger == nil {
-		conf.Logger = logrus.New()
-		if conf.LogLevel != (logrus.Level(0)) { // todo fix panic level
-			conf.Logger.SetLevel(conf.LogLevel)
-		}
-		conf.Logger.SetFormatter(
-			&logrus.TextFormatter{
-				ForceColors:     true,
-				FullTimestamp:   true,
-				TimestampFormat: time.RFC3339Nano,
-			},
-		)
+	// if user has already set logger, skip
+	if conf.Logger != nil {
+		return
 	}
+
+	// otherwise, create a new logger for the user
+	logger := logrus.New()
+	// set log level if user has specified one
+	if conf.LogLevel != (logrus.Level(0)) {
+		logger.SetLevel(conf.LogLevel)
+	}
+	logger.SetFormatter(
+		&logrus.TextFormatter{
+			ForceColors:     true,
+			FullTimestamp:   true,
+			TimestampFormat: time.RFC3339Nano,
+		},
+	)
+	conf.Logger = logger
+
 }
 
 func setRetryPolicy(opsGenieClient *OpsGenieClient, cfg *Config) {
@@ -247,9 +254,8 @@ func NewOpsGenieClient(cfg *Config) (*OpsGenieClient, error) {
 }
 
 func printInfoLog(client *OpsGenieClient) {
-	client.Config.Logger.Infof("Client is configured with ApiUrl: %s, LogLevel: %s, RetryMaxCount: %v",
+	client.Config.Logger.Infof("Client is configured with ApiUrl: %s, RetryMaxCount: %v",
 		client.Config.OpsGenieAPIURL,
-		client.Config.Logger.GetLevel().String(),
 		client.RetryableClient.RetryMax)
 }
 

--- a/client/config.go
+++ b/client/config.go
@@ -1,11 +1,12 @@
 package client
 
 import (
+	"net/http"
+	"time"
+
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"net/http"
-	"time"
 )
 
 type Config struct {
@@ -29,7 +30,7 @@ type Config struct {
 
 	LogLevel logrus.Level
 
-	Logger *logrus.Logger
+	Logger logrus.FieldLogger
 }
 
 type ApiUrl string


### PR DESCRIPTION
There is no way currently to add a set of fields to all logs from the opsgenie API since we are accepting a logrus.Logger in the config struct. By changing this to a FieldLogger users will be able to either continue submitting a logrus.Logger, or submit a logrus.Entry with a set of fields they want in all opsgenie logs predefined.

The only adverse effect is that the FieldLogger interface does not have a GetLevel method, meaning I've had to remove that from the printInfoLog function. This doesn't seem like an issue to me, would like opinions on this.