### PR TITLE
Change date location to UTC before formatting

### DIFF
--- a/schedule/request.go
+++ b/schedule/request.go
@@ -249,7 +249,7 @@ func (r *GetTimelineRequest) RequestParams() map[string]string {
 	params["intervalUnit"] = string(r.IntervalUnit)
 
 	if r.Date != nil {
-		params["date"] = r.Date.Format("2006-01-02T15:04:05.000Z")
+		params["date"] = r.Date.UTC().Format("2006-01-02T15:04:05.000Z")
 	}
 	return params
 }

--- a/schedule/who_is_oncall_request.go
+++ b/schedule/who_is_oncall_request.go
@@ -45,7 +45,7 @@ func (r *GetOnCallsRequest) RequestParams() map[string]string {
 	}
 
 	if r.Date != nil {
-		params["date"] = r.Date.Format("2006-01-02T15:04:05.000Z")
+		params["date"] = r.Date.UTC().Format("2006-01-02T15:04:05.000Z")
 	}
 
 	return params
@@ -89,7 +89,7 @@ func (r *GetNextOnCallsRequest) RequestParams() map[string]string {
 	}
 
 	if r.Date != nil {
-		params["date"] = r.Date.Format("2006-01-02T15:04:05.000Z")
+		params["date"] = r.Date.UTC().Format("2006-01-02T15:04:05.000Z")
 	}
 
 	return params


### PR DESCRIPTION
For some reason, the time format `2006-01-02T15:04:05.000Z` is used instead of the idiomatic `time.RFC3339` or `time.RFC3339Nano`.

This does not work well for different time zones or daylights saving time ([playground link](https://go.dev/play/p/0N0zRc-hLuk)).

One solution would be to change the format to `time.RFC3339Nano`, however there is a risk that the API won't handle the different format.

Instead, we should at least make sure that the time is set to the UTC location.
