### PR TITLE
update service result struct

### DIFF
--- a/service/service_result.go
+++ b/service/service_result.go
@@ -8,7 +8,13 @@ type Service struct {
 	Description string     `json:"description"`
 	Visibility  Visibility `json:"visibility"`
 	TeamId      string     `json:"teamId"`
+	Links       Links      `json:"links"`
 	Tags        []string   `json:"tags,omitempty"`
+}
+
+type Links struct {
+	Web string `json:"web"`
+	Api string `json:"api"`
 }
 
 type CreateResult struct {


### PR DESCRIPTION
Fixes #116

Define a Links struct that is a property for the service struct that can decode the `links` property in a Get or List Services response