### PR TITLE
Responder type escalation in alert policies

### DIFF
--- a/policy/request.go
+++ b/policy/request.go
@@ -681,8 +681,8 @@ func ValidateDelayAction(action DelayAction) error {
 
 func ValidateResponders(responders *[]alert.Responder) error {
 	for _, responder := range *responders {
-		if responder.Type != alert.UserResponder && responder.Type != alert.TeamResponder {
-			return errors.New("responder type for alert policy should be one of team or user")
+		if responder.Type != alert.UserResponder && responder.Type != alert.TeamResponder && responder.Type != alert.EscalationResponder {
+			 return errors.New("responder type for alert policy should be one of team, user or escalation")
 		}
 		if responder.Id == "" {
 			return errors.New("responder id should be provided")


### PR DESCRIPTION
This commit allows to set responder type `escalation` to alert policies.

Closes: #118