### PR TITLE
Support updating service's tags

### DIFF
--- a/service/service_request.go
+++ b/service/service_request.go
@@ -45,6 +45,7 @@ type UpdateRequest struct {
 	Name        string     `json:"name,omitempty"`
 	Description string     `json:"description,omitempty"`
 	Visibility  Visibility `json:"visibility,omitempty"`
+	Tags        []string   `json:"tags,omitempty"`
 }
 
 func (r *UpdateRequest) Validate() error {


### PR DESCRIPTION
This is now apparently [supported](https://docs.opsgenie.com/docs/service-api#update-service) but missing from the SDK.

Needed by https://github.com/opsgenie/terraform-provider-opsgenie/pull/149