### PR TITLE
Add escalation schedule group in responder type in alert policy

### DIFF
--- a/alert/responder.go
+++ b/alert/responder.go
@@ -3,12 +3,11 @@ package alert
 type ResponderType string
 
 const (
-	UserResponder        ResponderType = "user"
-	TeamResponder        ResponderType = "team"
-	EscalationResponder  ResponderType = "escalation"
-	ScheduleResponder    ResponderType = "schedule"
-	GroupResponder       ResponderType = "group"
-	UnsupportedResponder ResponderType = "unsupported"
+	UserResponder       ResponderType = "user"
+	TeamResponder       ResponderType = "team"
+	EscalationResponder ResponderType = "escalation"
+	ScheduleResponder   ResponderType = "schedule"
+	GroupResponder      ResponderType = "group"
 )
 
 type Responder struct {

--- a/alert/responder.go
+++ b/alert/responder.go
@@ -3,10 +3,12 @@ package alert
 type ResponderType string
 
 const (
-	UserResponder       ResponderType = "user"
-	TeamResponder       ResponderType = "team"
-	EscalationResponder ResponderType = "escalation"
-	ScheduleResponder   ResponderType = "schedule"
+	UserResponder        ResponderType = "user"
+	TeamResponder        ResponderType = "team"
+	EscalationResponder  ResponderType = "escalation"
+	ScheduleResponder    ResponderType = "schedule"
+	GroupResponder       ResponderType = "group"
+	UnsupportedResponder ResponderType = "unsupported"
 )
 
 type Responder struct {

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -126,14 +126,14 @@ func TestCreateAlertPolicy_Validate(t *testing.T) {
 
 	req.Responders = &[]alert.Responder{
 		{
-			Type:     alert.ScheduleResponder,
+			Type:     alert.UnsupportedResponder,
 			Name:     "",
 			Id:       "",
 			Username: "",
 		},
 	}
 	err = req.Validate()
-	assert.Equal(t, err.Error(), errors.New("responder type for alert policy should be one of team or user").Error())
+	assert.Equal(t, err.Error(), errors.New("responder type for alert policy should be one of team, user, escalation, schedule or group").Error())
 
 	req.Responders = &[]alert.Responder{
 		{
@@ -171,6 +171,72 @@ func TestCreateAlertPolicy_Validate(t *testing.T) {
 	req.Responders = &[]alert.Responder{
 		{
 			Type:     alert.TeamResponder,
+			Name:     "",
+			Id:       "teamId",
+			Username: "",
+		},
+	}
+	err = req.Validate()
+	assert.Nil(t, err)
+
+	req.Responders = &[]alert.Responder{
+		{
+			Type:     alert.EscalationResponder,
+			Name:     "",
+			Id:       "",
+			Username: "user1",
+		},
+	}
+	err = req.Validate()
+	assert.Equal(t, err.Error(), errors.New("responder id should be provided").Error())
+
+	req.Responders = &[]alert.Responder{
+		{
+			Type:     alert.EscalationResponder,
+			Name:     "",
+			Id:       "teamId",
+			Username: "",
+		},
+	}
+	err = req.Validate()
+	assert.Nil(t, err)
+
+	req.Responders = &[]alert.Responder{
+		{
+			Type:     alert.ScheduleResponder,
+			Name:     "",
+			Id:       "",
+			Username: "user1",
+		},
+	}
+	err = req.Validate()
+	assert.Equal(t, err.Error(), errors.New("responder id should be provided").Error())
+
+	req.Responders = &[]alert.Responder{
+		{
+			Type:     alert.ScheduleResponder,
+			Name:     "",
+			Id:       "teamId",
+			Username: "",
+		},
+	}
+	err = req.Validate()
+	assert.Nil(t, err)
+
+	req.Responders = &[]alert.Responder{
+		{
+			Type:     alert.GroupResponder,
+			Name:     "",
+			Id:       "",
+			Username: "user1",
+		},
+	}
+	err = req.Validate()
+	assert.Equal(t, err.Error(), errors.New("responder id should be provided").Error())
+
+	req.Responders = &[]alert.Responder{
+		{
+			Type:     alert.GroupResponder,
 			Name:     "",
 			Id:       "teamId",
 			Username: "",

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -126,14 +126,14 @@ func TestCreateAlertPolicy_Validate(t *testing.T) {
 
 	req.Responders = &[]alert.Responder{
 		{
-			Type:     alert.UnsupportedResponder,
+			Type:     alert.GroupResponder,
 			Name:     "",
 			Id:       "",
 			Username: "",
 		},
 	}
 	err = req.Validate()
-	assert.Equal(t, err.Error(), errors.New("responder type for alert policy should be one of team, user, escalation, schedule or group").Error())
+	assert.Equal(t, err.Error(), errors.New("responder type for alert policy should be one of team, user, escalation or schedule").Error())
 
 	req.Responders = &[]alert.Responder{
 		{
@@ -215,28 +215,6 @@ func TestCreateAlertPolicy_Validate(t *testing.T) {
 	req.Responders = &[]alert.Responder{
 		{
 			Type:     alert.ScheduleResponder,
-			Name:     "",
-			Id:       "teamId",
-			Username: "",
-		},
-	}
-	err = req.Validate()
-	assert.Nil(t, err)
-
-	req.Responders = &[]alert.Responder{
-		{
-			Type:     alert.GroupResponder,
-			Name:     "",
-			Id:       "",
-			Username: "user1",
-		},
-	}
-	err = req.Validate()
-	assert.Equal(t, err.Error(), errors.New("responder id should be provided").Error())
-
-	req.Responders = &[]alert.Responder{
-		{
-			Type:     alert.GroupResponder,
 			Name:     "",
 			Id:       "teamId",
 			Username: "",

--- a/policy/request.go
+++ b/policy/request.go
@@ -681,8 +681,8 @@ func ValidateDelayAction(action DelayAction) error {
 
 func ValidateResponders(responders *[]alert.Responder) error {
 	for _, responder := range *responders {
-		if responder.Type != alert.UserResponder && responder.Type != alert.TeamResponder && responder.Type != alert.EscalationResponder && responder.Type != alert.ScheduleResponder && responder.Type != alert.GroupResponder {
-			return errors.New("responder type for alert policy should be one of team, user, escalation, schedule or group")
+		if responder.Type != alert.UserResponder && responder.Type != alert.TeamResponder && responder.Type != alert.EscalationResponder && responder.Type != alert.ScheduleResponder {
+			return errors.New("responder type for alert policy should be one of team, user, escalation or schedule")
 		}
 		if responder.Id == "" {
 			return errors.New("responder id should be provided")

--- a/policy/request.go
+++ b/policy/request.go
@@ -681,8 +681,8 @@ func ValidateDelayAction(action DelayAction) error {
 
 func ValidateResponders(responders *[]alert.Responder) error {
 	for _, responder := range *responders {
-		if responder.Type != alert.UserResponder && responder.Type != alert.TeamResponder {
-			return errors.New("responder type for alert policy should be one of team or user")
+		if responder.Type != alert.UserResponder && responder.Type != alert.TeamResponder && responder.Type != alert.EscalationResponder {
+			 return errors.New("responder type for alert policy should be one of team, user or escalation")
 		}
 		if responder.Id == "" {
 			return errors.New("responder id should be provided")

--- a/policy/request.go
+++ b/policy/request.go
@@ -681,8 +681,8 @@ func ValidateDelayAction(action DelayAction) error {
 
 func ValidateResponders(responders *[]alert.Responder) error {
 	for _, responder := range *responders {
-		if responder.Type != alert.UserResponder && responder.Type != alert.TeamResponder && responder.Type != alert.EscalationResponder {
-			 return errors.New("responder type for alert policy should be one of team, user or escalation")
+		if responder.Type != alert.UserResponder && responder.Type != alert.TeamResponder && responder.Type != alert.EscalationResponder && responder.Type != alert.ScheduleResponder && responder.Type != alert.GroupResponder {
+			return errors.New("responder type for alert policy should be one of team, user, escalation, schedule or group")
 		}
 		if responder.Id == "" {
 			return errors.New("responder id should be provided")


### PR DESCRIPTION
This is needed to support `escalation`, `schedule` and `group` in `responder` type in alert policy in opsgenie-terraform-provider: https://github.com/opsgenie/terraform-provider-opsgenie/issues/293