### PR TITLE
Add escalation schedule in responder type in alert policy

### DIFF
--- a/alert/responder.go
+++ b/alert/responder.go
@@ -7,7 +7,6 @@ const (
 	TeamResponder       ResponderType = "team"
 	EscalationResponder ResponderType = "escalation"
 	ScheduleResponder   ResponderType = "schedule"
-	GroupResponder      ResponderType = "group"
 )
 
 type Responder struct {

--- a/alert/responder.go
+++ b/alert/responder.go
@@ -7,6 +7,7 @@ const (
 	TeamResponder       ResponderType = "team"
 	EscalationResponder ResponderType = "escalation"
 	ScheduleResponder   ResponderType = "schedule"
+	GroupResponder      ResponderType = "group"
 )
 
 type Responder struct {

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -126,7 +126,7 @@ func TestCreateAlertPolicy_Validate(t *testing.T) {
 
 	req.Responders = &[]alert.Responder{
 		{
-			Type:     alert.GroupResponder,
+			Type:     "",
 			Name:     "",
 			Id:       "",
 			Username: "",

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -126,14 +126,14 @@ func TestCreateAlertPolicy_Validate(t *testing.T) {
 
 	req.Responders = &[]alert.Responder{
 		{
-			Type:     alert.ScheduleResponder,
+			Type:     alert.GroupResponder,
 			Name:     "",
 			Id:       "",
 			Username: "",
 		},
 	}
 	err = req.Validate()
-	assert.Equal(t, err.Error(), errors.New("responder type for alert policy should be one of team or user").Error())
+	assert.Equal(t, err.Error(), errors.New("responder type for alert policy should be one of team, user, escalation or schedule").Error())
 
 	req.Responders = &[]alert.Responder{
 		{
@@ -171,6 +171,50 @@ func TestCreateAlertPolicy_Validate(t *testing.T) {
 	req.Responders = &[]alert.Responder{
 		{
 			Type:     alert.TeamResponder,
+			Name:     "",
+			Id:       "teamId",
+			Username: "",
+		},
+	}
+	err = req.Validate()
+	assert.Nil(t, err)
+
+	req.Responders = &[]alert.Responder{
+		{
+			Type:     alert.EscalationResponder,
+			Name:     "",
+			Id:       "",
+			Username: "user1",
+		},
+	}
+	err = req.Validate()
+	assert.Equal(t, err.Error(), errors.New("responder id should be provided").Error())
+
+	req.Responders = &[]alert.Responder{
+		{
+			Type:     alert.EscalationResponder,
+			Name:     "",
+			Id:       "teamId",
+			Username: "",
+		},
+	}
+	err = req.Validate()
+	assert.Nil(t, err)
+
+	req.Responders = &[]alert.Responder{
+		{
+			Type:     alert.ScheduleResponder,
+			Name:     "",
+			Id:       "",
+			Username: "user1",
+		},
+	}
+	err = req.Validate()
+	assert.Equal(t, err.Error(), errors.New("responder id should be provided").Error())
+
+	req.Responders = &[]alert.Responder{
+		{
+			Type:     alert.ScheduleResponder,
 			Name:     "",
 			Id:       "teamId",
 			Username: "",

--- a/policy/request.go
+++ b/policy/request.go
@@ -681,8 +681,8 @@ func ValidateDelayAction(action DelayAction) error {
 
 func ValidateResponders(responders *[]alert.Responder) error {
 	for _, responder := range *responders {
-		if responder.Type != alert.UserResponder && responder.Type != alert.TeamResponder {
-			return errors.New("responder type for alert policy should be one of team or user")
+		if responder.Type != alert.UserResponder && responder.Type != alert.TeamResponder && responder.Type != alert.EscalationResponder {
+			 return errors.New("responder type for alert policy should be one of team, user or escalation")
 		}
 		if responder.Id == "" {
 			return errors.New("responder id should be provided")

--- a/policy/request.go
+++ b/policy/request.go
@@ -681,8 +681,8 @@ func ValidateDelayAction(action DelayAction) error {
 
 func ValidateResponders(responders *[]alert.Responder) error {
 	for _, responder := range *responders {
-		if responder.Type != alert.UserResponder && responder.Type != alert.TeamResponder && responder.Type != alert.EscalationResponder {
-			 return errors.New("responder type for alert policy should be one of team, user or escalation")
+		if responder.Type != alert.UserResponder && responder.Type != alert.TeamResponder && responder.Type != alert.EscalationResponder && responder.Type != alert.ScheduleResponder {
+			return errors.New("responder type for alert policy should be one of team, user, escalation or schedule")
 		}
 		if responder.Id == "" {
 			return errors.New("responder id should be provided")


### PR DESCRIPTION
This is needed to support escalation, schedule and group in responder type in alert policy in opsgenie-terraform-provider: https://github.com/opsgenie/terraform-provider-opsgenie/issues/293