### PR TITLE
Bugfix: Adding `type` request param to Maintenance ListRequest

### DIFF
--- a/maintenance/request.go
+++ b/maintenance/request.go
@@ -157,6 +157,15 @@ func (r *ListRequest) Method() string {
 	return http.MethodGet
 }
 
+func (r *ListRequest) RequestParams() map[string]string {
+	if r.Type == "" {
+		return nil
+	}
+	params := make(map[string]string)
+	params["type"] = string(r.Type)
+	return params
+}
+
 type CancelRequest struct {
 	client.BaseRequest
 	Id string


### PR DESCRIPTION
This is needed to align with [API docs](https://docs.opsgenie.com/docs/maintenance-api#list-maintenance) where we are able to list only a type of windows.