### PR TITLE
Combine the identical if-else branches in client/client.go

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -262,9 +262,6 @@ func printInfoLog(client *OpsGenieClient) {
 func (cli *OpsGenieClient) defineErrorHandler(resp *http.Response, err error, numTries int) (*http.Response, error) {
 	if err != nil {
 		cli.Config.Logger.Errorf("Unable to send the request %s ", err.Error())
-		if err == context.DeadlineExceeded {
-			return nil, err
-		}
 		return nil, err
 	}
 	resp.Header.Add("retryCount", strconv.Itoa(numTries))


### PR DESCRIPTION
in client/client.go, the following if-else branches contain the identical logic and should be combined:
```go
               if err == context.DeadlineExceeded {
                       return nil, err
               }
               return nil, err
```