### PR TITLE
Update APIBasedIntegrationRequest to include AllowConfigurationAccess

### DIFF
--- a/integration/request.go
+++ b/integration/request.go
@@ -48,6 +48,7 @@ type APIBasedIntegrationRequest struct {
 	client.BaseRequest
 	Name                        string        `json:"name"`
 	Type                        string        `json:"type"`
+	AllowConfigurationAccess    *bool         `json:"allowConfigurationAccess"`
 	AllowWriteAccess            *bool         `json:"allowWriteAccess"`
 	IgnoreRespondersFromPayload *bool         `json:"ignoreRespondersFromPayload"`
 	SuppressNotifications       *bool         `json:"suppressNotifications"`


### PR DESCRIPTION
Surfacing the AllowConfigurationAccess parameter to be used when created API based integrations. This is to address this issue (https://github.com/opsgenie/terraform-provider-opsgenie/issues/436) in the Opsgenie terraform provider. 